### PR TITLE
MOSIP-31721 | Add one more condition to check whether the value of the error is null or not

### DIFF
--- a/automationtests/src/main/java/io/mosip/testrig/apirig/authentication/fw/util/OutputValidationUtil.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/authentication/fw/util/OutputValidationUtil.java
@@ -601,7 +601,7 @@ public class OutputValidationUtil extends AuthTestsUtil {
 			errors.put(tempJson);
 		}
 
-		if (errors.length() == 0) {
+		if (errors == null ||errors.length() == 0) {
 			return;
 		}
 


### PR DESCRIPTION
I added an additional condition to the output validation to check whether the error value is null. If it is null, it should not proceed to the log server bugs method.