### PR TITLE
MOSIP-30310 | Ignoring Generete VID test case from the report as it is not valid.

### DIFF
--- a/automationtests/src/main/java/io/mosip/testrig/apirig/global/utils/GlobalConstants.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/global/utils/GlobalConstants.java
@@ -209,6 +209,7 @@ public class GlobalConstants {
 	public static final String VID_FEATURE_NOT_SUPPORTED = "VID feature not supported. Hence skipping the testcase";
 	public static final String UIN_FEATURE_NOT_SUPPORTED = "UIN feature not supported. Hence skipping the testcase";
 	public static final String FEATURE_NOT_SUPPORTED_MESSAGE = "feature not supported. Hence skipping the testcase";
+	public static final String VID_GENERATED_USING_RESIDENT_API_SO_FEATURE_NOT_SUPPORTED_OR_NEEDED_MESSAGE = "Generating VID using Resident API. So, this feature not supported/needed. Hence skipping the testcase";
 	public static final String SERVICE_NOT_DEPLOYED_MESSAGE = "Service not deployed. Hence skipping the testcase";
 	public static final String FEATURE_NOT_SUPPORTED = "feature not supported";
 	public static final String SERVICE_NOT_DEPLOYED = "Service not deployed";

--- a/automationtests/src/main/java/io/mosip/testrig/apirig/testscripts/SimplePostForAutoGenId.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/testscripts/SimplePostForAutoGenId.java
@@ -103,7 +103,7 @@ public class SimplePostForAutoGenId extends AdminTestUtil implements ITest {
 				if (((BaseTestCase.currentModule.equals("auth") || BaseTestCase.currentModule.equals("esignet"))
 						&& (testCaseName.startsWith("auth_GenerateVID_")
 								|| testCaseName.startsWith("ESignetIdR_Generate")))) {
-					throw new SkipException("Generating VID using IdRepo API. Hence skipping this test case");
+					throw new SkipException(GlobalConstants.VID_GENERATED_USING_RESIDENT_API_SO_FEATURE_NOT_SUPPORTED_OR_NEEDED_MESSAGE);
 //					qa115 - f
 //					cam   - t f
 //					dev	  - t 


### PR DESCRIPTION
Ignoring Generate VID test case from the report as we are not generating VID using resident API. So, ignoring these idrepo API's.