### PR TITLE
MOSIP-29560 | Modify logic to accept phone also a OTP channel

### DIFF
--- a/automationtests/src/main/java/io/mosip/testrig/apirig/admin/fw/util/AdminTestUtil.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/admin/fw/util/AdminTestUtil.java
@@ -6377,9 +6377,11 @@ public class AdminTestUtil extends BaseTestCase {
 			if (request.has("otp")) {
 				if (request.getString("otp").endsWith(GlobalConstants.MOSIP_NET)
 						|| request.getString("otp").endsWith(GlobalConstants.MAILINATOR_COM)
-						|| request.getString("otp").endsWith(GlobalConstants.MOSIP_IO)) {
-
+						|| request.getString("otp").endsWith(GlobalConstants.MOSIP_IO)
+						|| request.getString("otp").endsWith(GlobalConstants.OTP_AS_PHONE)) {
 					emailId = request.get("otp").toString();
+					if (emailId.endsWith(GlobalConstants.OTP_AS_PHONE))
+						emailId = emailId.replace(GlobalConstants.OTP_AS_PHONE, "");
 					logger.info(emailId);
 					otp = MockSMTPListener.getOtp(emailId);
 					request.put("otp", otp);
@@ -6407,8 +6409,12 @@ public class AdminTestUtil extends BaseTestCase {
 				if (request.has(GlobalConstants.REQUEST)) {
 					if (request.getJSONObject(GlobalConstants.REQUEST).has("otp")) {
 						if (request.getJSONObject(GlobalConstants.REQUEST).getString("otp")
-								.endsWith(GlobalConstants.MOSIP_NET)) {
+								.endsWith(GlobalConstants.MOSIP_NET)
+								|| request.getJSONObject(GlobalConstants.REQUEST).getString("otp")
+										.endsWith(GlobalConstants.OTP_AS_PHONE)) {
 							emailId = request.getJSONObject(GlobalConstants.REQUEST).get("otp").toString();
+							if (emailId.endsWith(GlobalConstants.OTP_AS_PHONE))
+								emailId = emailId.replace(GlobalConstants.OTP_AS_PHONE, "");
 							logger.info(emailId);
 							otp = MockSMTPListener.getOtp(emailId);
 							request.getJSONObject(GlobalConstants.REQUEST).put("otp", otp);
@@ -6454,10 +6460,16 @@ public class AdminTestUtil extends BaseTestCase {
 											|| request.getJSONObject(GlobalConstants.REQUEST)
 													.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
 													.getString(GlobalConstants.CHALLENGE)
-													.endsWith(GlobalConstants.MOSIP_IO)) {
+													.endsWith(GlobalConstants.MOSIP_IO)
+											|| request.getJSONObject(GlobalConstants.REQUEST)
+													.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
+													.getString(GlobalConstants.CHALLENGE)
+													.endsWith(GlobalConstants.OTP_AS_PHONE)) {
 										emailId = request.getJSONObject(GlobalConstants.REQUEST)
 												.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
 												.getString(GlobalConstants.CHALLENGE);
+										if (emailId.endsWith(GlobalConstants.OTP_AS_PHONE))
+											emailId = emailId.replace(GlobalConstants.OTP_AS_PHONE, "");
 										logger.info(emailId);
 										otp = MockSMTPListener.getOtp(emailId);
 										request.getJSONObject(GlobalConstants.REQUEST)
@@ -6479,8 +6491,12 @@ public class AdminTestUtil extends BaseTestCase {
 			if (request.has(GlobalConstants.REQUEST)) {
 				if (request.getJSONObject(GlobalConstants.REQUEST).has("otp")) {
 					if (request.getJSONObject(GlobalConstants.REQUEST).getString("otp")
-							.endsWith(GlobalConstants.MOSIP_NET)) {
+							.endsWith(GlobalConstants.MOSIP_NET)
+							|| request.getJSONObject(GlobalConstants.REQUEST).getString("otp")
+									.endsWith(GlobalConstants.OTP_AS_PHONE)) {
 						emailId = request.getJSONObject(GlobalConstants.REQUEST).get("otp").toString();
+						if (emailId.endsWith(GlobalConstants.OTP_AS_PHONE))
+							emailId = emailId.replace(GlobalConstants.OTP_AS_PHONE, "");
 						logger.info(emailId);
 						otp = MockSMTPListener.getOtp(emailId);
 						request.getJSONObject(GlobalConstants.REQUEST).put("otp", otp);
@@ -6496,10 +6512,16 @@ public class AdminTestUtil extends BaseTestCase {
 									.has(GlobalConstants.CHALLENGE)) {
 								if (request.getJSONObject(GlobalConstants.REQUEST)
 										.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
-										.getString(GlobalConstants.CHALLENGE).endsWith(GlobalConstants.MOSIP_NET)) {
+										.getString(GlobalConstants.CHALLENGE).endsWith(GlobalConstants.MOSIP_NET)
+										|| request.getJSONObject(GlobalConstants.REQUEST)
+												.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
+												.getString(GlobalConstants.CHALLENGE)
+												.endsWith(GlobalConstants.OTP_AS_PHONE)) {
 									emailId = request.getJSONObject(GlobalConstants.REQUEST)
 											.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
 											.getString(GlobalConstants.CHALLENGE);
+									if (emailId.endsWith(GlobalConstants.OTP_AS_PHONE))
+										emailId = emailId.replace(GlobalConstants.OTP_AS_PHONE, "");
 									logger.info(emailId);
 									otp = MockSMTPListener.getOtp(emailId);
 									request.getJSONObject(GlobalConstants.REQUEST)
@@ -6520,8 +6542,12 @@ public class AdminTestUtil extends BaseTestCase {
 			if (request.has(GlobalConstants.REQUEST)) {
 				if (request.getJSONObject(GlobalConstants.REQUEST).has("otp")) {
 					if (request.getJSONObject(GlobalConstants.REQUEST).getString("otp")
-							.endsWith(GlobalConstants.MOSIP_NET)) {
+							.endsWith(GlobalConstants.MOSIP_NET)
+							|| request.getJSONObject(GlobalConstants.REQUEST).getString("otp")
+									.endsWith(GlobalConstants.OTP_AS_PHONE)) {
 						emailId = request.getJSONObject(GlobalConstants.REQUEST).get("otp").toString();
+						if (emailId.endsWith(GlobalConstants.OTP_AS_PHONE))
+							emailId = emailId.replace(GlobalConstants.OTP_AS_PHONE, "");
 						logger.info(emailId);
 						otp = MockSMTPListener.getOtp(emailId);
 						request.getJSONObject(GlobalConstants.REQUEST).put("otp", otp);
@@ -6534,10 +6560,15 @@ public class AdminTestUtil extends BaseTestCase {
 								.getJSONObject(0).has(GlobalConstants.CHALLENGE)) {
 							if (request.getJSONObject(GlobalConstants.REQUEST)
 									.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
-									.getString(GlobalConstants.CHALLENGE).endsWith(GlobalConstants.MOSIP_NET)) {
+									.getString(GlobalConstants.CHALLENGE).endsWith(GlobalConstants.MOSIP_NET)
+									|| request.getJSONObject(GlobalConstants.REQUEST)
+											.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
+											.getString(GlobalConstants.CHALLENGE).endsWith(GlobalConstants.OTP_AS_PHONE)) {
 								emailId = request.getJSONObject(GlobalConstants.REQUEST)
 										.getJSONArray(GlobalConstants.CHALLENGELIST).getJSONObject(0)
 										.getString(GlobalConstants.CHALLENGE);
+								if (emailId.endsWith(GlobalConstants.OTP_AS_PHONE))
+									emailId = emailId.replace(GlobalConstants.OTP_AS_PHONE, "");
 								logger.info(emailId);
 								otp = MockSMTPListener.getOtp(emailId);
 								request.getJSONObject(GlobalConstants.REQUEST)


### PR DESCRIPTION
Added logic in smtpOtpHandler method to accept phone as a OTP channel to extract OTP from SMTP listener.