### PR TITLE
ES-540 | Changed the Aud URL as per the requirement.

### DIFF
--- a/automationtests/src/main/java/io/mosip/testrig/apirig/admin/fw/util/AdminTestUtil.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/admin/fw/util/AdminTestUtil.java
@@ -3723,7 +3723,7 @@ public class AdminTestUtil extends BaseTestCase {
 
 	public static String signJWKForMock(String clientId, String accessToken, RSAKey jwkKey, String testCaseName) {
 //		String tempUrl = getValueFromActuator(GlobalConstants.RESIDENT_DEFAULT_PROPERTIES, "mosip.iam.base.url");
-		String tempUrl = getValueFromEsignetWellKnownEndPoint("issuer") + "/v1/esignet";
+		String tempUrl = getValueFromEsignetWellKnownEndPoint("issuer");
 		if (tempUrl.contains("esignet.")) {
 			tempUrl = tempUrl.replace("esignet.", propsKernel.getProperty("esignetMockBaseURL"));
 		}
@@ -3772,7 +3772,7 @@ public class AdminTestUtil extends BaseTestCase {
 
 	public static String signJWK(String clientId, String accessToken, RSAKey jwkKey, String testCaseName) {
 //		String tempUrl = getValueFromActuator(GlobalConstants.RESIDENT_DEFAULT_PROPERTIES, "mosip.iam.base.url");
-		String tempUrl = getValueFromEsignetWellKnownEndPoint("issuer") + "/v1/esignet";
+		String tempUrl = getValueFromEsignetWellKnownEndPoint("issuer");
 		int idTokenExpirySecs = Integer.parseInt(getValueFromEsignetActuator(GlobalConstants.ESIGNET_DEFAULT_PROPERTIES,
 				GlobalConstants.MOSIP_ESIGNET_ID_TOKEN_EXPIRE_SECONDS));
 		JWSSigner signer;


### PR DESCRIPTION
The 'Get credential VCI' API is failing because I am passing the wrong URL for the Proof JWT. As per the requirements, I have updated the URL in both the 'signJWK' and 'signJWKForMock' methods.