### PR TITLE
ES-471 | Change Expected value in output validation for get credential API test cases

### DIFF
--- a/automationtests/src/main/resources/esignet/VCINegTC/GetCredential/GetCredential.yml
+++ b/automationtests/src/main/resources/esignet/VCINegTC/GetCredential/GetCredential.yml
@@ -122,7 +122,7 @@ GetCredentialNegTC:
         "proof_jwt": "$PROOFJWT$"
 }'
       output: '{
-      "error": "unknown_error"
+      "error": "not_implemented"
 }'
 
    ESignet_GetCredential_uin_IdpAccessToken_Inval2_Format_Neg:
@@ -143,7 +143,7 @@ GetCredentialNegTC:
         "proof_jwt": "$PROOFJWT$"
 }'
       output: '{
-      "error": "unknown_error"
+      "error": "not_implemented"
 }'
 
    ESignet_GetCredential_uin_IdpAccessToken_Inval3_Format_Neg:


### PR DESCRIPTION
Changed expected value in YAML of get credential API  as mentioned in the ticket.