### PR TITLE
ES-471 | Change Expected value in output validation for get credential API test cases

### DIFF
--- a/automationtests/src/main/resources/esignet/VCINegTC/GetCredential/GetCredential.yml
+++ b/automationtests/src/main/resources/esignet/VCINegTC/GetCredential/GetCredential.yml
@@ -831,5 +831,5 @@ GetCredentialNegTC:
         "proof_jwt": "$PROOFJWT$"
 }'
       output: '{
-      "error":"invalid_proof"
+      "error":"vci_exchange_failed"
 }'


### PR DESCRIPTION
Changed expected value in YAML of get credential API as mentioned in the ticket.