### PR TITLE
MOSIP-30056 | Integrate DB to delete the partners geenerated for esignet module

### DIFF
--- a/automationtests/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
@@ -47,6 +47,22 @@ public class DBManager {
 				}
 			}
 		}
+	
+	public static void clearKeyManagerDbDataForEsignet() {
+		Session session = null;
+		try {
+			session = getDataBaseConnection(ConfigManager.getKMDbUrl(), ConfigManager.getKMDbUser(),
+					ConfigManager.getKMDbPass(), ConfigManager.getKMDbSchema());
+			executeQueries(session, MosipTestRunner.getGlobalResourcePath() + "/"	+ "config/keyManagerDataDeleteQueriesForEsignet.txt");				
+			} catch (Exception e) {
+				logger.error("Error:: While executing PMS DB Quiries." + e.getMessage());
+			} finally {
+				if (session != null) {
+					session.close();
+				}
+			}
+		}
+	
 	public static void clearMasterDbData() {
 		Session session = null;
 		try {
@@ -61,6 +77,37 @@ public class DBManager {
 				}
 			}
 		}
+	
+	public static void clearMasterDbDataForEsignet() {
+		Session session = null;
+		try {
+			session = getDataBaseConnection(ConfigManager.getMASTERDbUrl(), ConfigManager.getMasterDbUser(),
+					ConfigManager.getMasterDbPass(), ConfigManager.getMasterDbSchema());
+			executeQueries(session,  MosipTestRunner.getGlobalResourcePath() + "/"	+ "config/masterDataDeleteQueriesForEsignet.txt");
+			} catch (Exception e) {
+				logger.error("Error:: While executing MASTER DB Quiries." + e.getMessage());
+			} finally {
+				if (session != null) {
+					session.close();
+				}
+			}
+		}
+	
+	public static void clearIDADbDataForEsignet() {
+		Session session = null;
+		try {
+			session = getDataBaseConnection(ConfigManager.getIdaDbUrl(), ConfigManager.getIdaDbUser(),
+					ConfigManager.getPMSDbPass(), ConfigManager.getIdaDbSchema());
+			executeQueries(session,  MosipTestRunner.getGlobalResourcePath() + "/"	+ "config/idaDeleteQueriesForEsignet.txt");
+			} catch (Exception e) {
+				logger.error("Error:: While executing MASTER DB Quiries." + e.getMessage());
+			} finally {
+				if (session != null) {
+					session.close();
+				}
+			}
+		}
+	
 	public static void executeQueries(Session session, String strQueriesFilePath) throws Exception {
 		if (session != null) {
 				session.doWork(new Work() {

--- a/automationtests/src/main/java/io/mosip/testrig/apirig/service/BaseTestCase.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/service/BaseTestCase.java
@@ -284,6 +284,9 @@ public class BaseTestCase {
 
 			BaseTestCase.currentModule = GlobalConstants.ESIGNET;
 			BaseTestCase.certsForModule = GlobalConstants.ESIGNET;
+			DBManager.clearKeyManagerDbDataForEsignet();
+			DBManager.clearIDADbDataForEsignet();
+			DBManager.clearMasterDbDataForEsignet();
 			setReportName(GlobalConstants.ESIGNET);
 			AdminTestUtil.initiateesignetTest();
 			mockSMTPListener = new MockSMTPListener();

--- a/automationtests/src/main/resources/config/idaDeleteQueriesForEsignet.txt
+++ b/automationtests/src/main/resources/config/idaDeleteQueriesForEsignet.txt
@@ -1,0 +1,8 @@
+#####  DB queries to be executed to tear down the data used and generated during the test rig run
+
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=mosip_partnerorg%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=mosip_ekyc_partner%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=mosip_deviceorg%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=mosip_ftmorg%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from ida.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'

--- a/automationtests/src/main/resources/config/keyManagerDataDeleteQueriesForEsignet.txt
+++ b/automationtests/src/main/resources/config/keyManagerDataDeleteQueriesForEsignet.txt
@@ -1,0 +1,14 @@
+#####  DB queries to be executed to tear down the data used and generated during the test rig run
+
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=mosip_partnerorg%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=mosip_ekyc_partner%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=mosip_deviceorg%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=mosip_ftmorg%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from mosip_keymgr.keymgr.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=mosip_partnerorg%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=mosip_ekyc_partner%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=mosip_deviceorg%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=mosip_ftmorg%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from mosip_keymgr.keymgr.partner_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'

--- a/automationtests/src/main/resources/config/masterDataDeleteQueriesForEsignet.txt
+++ b/automationtests/src/main/resources/config/masterDataDeleteQueriesForEsignet.txt
@@ -1,0 +1,8 @@
+#####  DB queries to be executed to tear down the data used and generated during the test rig run
+
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=mosip_partnerorg%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=mosip_ekyc_partner%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=mosip_deviceorg%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=mosip_ftmorg%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforautomationesi%'
+delete from master.ca_cert_store WHERE cert_subject LIKE '%O=partnernameforesignet%'


### PR DESCRIPTION
I have added three methods to the DBManager class for deleting partners generated in the esignet module.