### PR TITLE
ES-1069

### DIFF
--- a/automationtests/src/main/resources/esignet/GenerateChallengeNegTC/GenerateChallengeWithTransID.hbs
+++ b/automationtests/src/main/resources/esignet/GenerateChallengeNegTC/GenerateChallengeWithTransID.hbs
@@ -5,6 +5,6 @@
     "identifier": "{{identifier}}",
     "captchaToken": "{{captchaToken}}",
     "purpose": "{{purpose}}",
-    "regenerate": "{{regenerate}}"
+    "regenerateChallenge": "{{regenerateChallenge}}"
   }
 }


### PR DESCRIPTION
ES-1069 | regenerate field is renamed to regenerateChallenge in generate challenge endpoint on signup flow