### PR TITLE
MOSIP-33136

### DIFF
--- a/automationtests/src/main/java/io/mosip/testrig/apirig/admin/fw/util/AdminTestUtil.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/admin/fw/util/AdminTestUtil.java
@@ -2921,7 +2921,7 @@ public class AdminTestUtil extends BaseTestCase {
 		return uri;
 	}
 	
-	public String getAuthTransactionId(String oidcTransactionId) {
+	public static String getAuthTransactionId(String oidcTransactionId) {
 	    final String transactionId = oidcTransactionId.replaceAll("_|-", "");
 	    String lengthOfTransactionId =  AdminTestUtil.getValueFromEsignetActuator("/mosip/mosip-config/esignet-default.properties", "mosip.esignet.auth-txn-id-length");
 	   int authTransactionIdLength = lengthOfTransactionId != null ? Integer.parseInt(lengthOfTransactionId): 0;

--- a/automationtests/src/main/java/io/mosip/testrig/apirig/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/automationtests/src/main/java/io/mosip/testrig/apirig/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -267,7 +267,8 @@ public class PostWithAutogenIdWithOtpGenerate extends AdminTestUtil implements I
 	@AfterClass(alwaysRun = true)
 	public void waittime() {
 		try {
-			if (!testCaseName.contains("Resident_CheckAidStatus")) {
+			if ((!testCaseName.contains(GlobalConstants.ESIGNET_))
+					&& (!testCaseName.contains("Resident_CheckAidStatus"))) {
 				long delayTime = Long.parseLong(properties.getProperty("Delaytime"));
 				if (!BaseTestCase.isTargetEnvLTS())
 					delayTime = Long.parseLong(properties.getProperty("uinGenDelayTime"))


### PR DESCRIPTION
MOSIP-33136 | changed getAuthTransactionId method into a static method and limited the wait time in the after class method