### PR TITLE
MOSIP-35082 - Fixing non English failure test cases

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
@@ -740,4 +740,10 @@ public class BaseTestCase extends AbstractTestNGSpringContextTests {
 		}
 		return numericString.toString();
 	}
+	
+	public static int getRecommendedHierarchyLevel() {
+		String recommendedHierarchLevel = getValueFromActuators(propsKernel.getProperty("actuatorMasterDataEndpoint"),
+				"/mosip-config/application-default.properties", "mosip.recommended.centers.locCode");
+		return Integer.parseInt(recommendedHierarchLevel);
+	}
 }

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -185,6 +185,7 @@ public class AdminTestUtil extends BaseTestCase {
 	public static final String AUTH_HEADER_VALUE = "Some String";
 	public static final String SIGNATURE_HEADERNAME = GlobalConstants.SIGNATURE;
 	public static String updatedPolicyId = "";
+	public static String currentLanguage;
 //	public static BioDataUtility bioDataUtil = new BioDataUtility();
 //
 //	public static BioDataUtility getBioDataUtil() {
@@ -6965,6 +6966,7 @@ public class AdminTestUtil extends BaseTestCase {
 		JSONObject responseJson = null;
 		String url = ApplnURI + props.getProperty("fetchLocationData");
 		String token = kernelAuthLib.getTokenByRole(GlobalConstants.ADMIN);
+		int recommendedHierarchyLevel = getRecommendedHierarchyLevel();
 		try {
 			response = RestClient.getRequestWithCookie(url, MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON,
 					GlobalConstants.AUTHORIZATION, token);
@@ -6975,15 +6977,21 @@ public class AdminTestUtil extends BaseTestCase {
 				JSONObject responseObject = responseJson.getJSONObject("response");
 				JSONArray data = responseObject.getJSONArray("data");
 
+				if (!(languageList.size() > 1)) {
+					currentLanguage = BaseTestCase.languageList.get(0);
+				}
+				
 				for (int i = 0; i < data.length(); i++) {
 					JSONObject entry = data.getJSONObject(i);
 					String langCode = entry.getString("langCode");
-
-					if (BaseTestCase.languageList.get(0).equals(langCode)) {
-						hierarchyName = entry.getString("hierarchyName");
-						hierarchyLevel = entry.getInt("hierarchyLevel");
-						parentLocCode = entry.optString("parentLocCode", "");
-						break;
+					hierarchyLevel = entry.getInt("hierarchyLevel");
+					
+					if (hierarchyLevel == recommendedHierarchyLevel) {
+						if (currentLanguage.equals(langCode)) {
+							hierarchyName = entry.getString("hierarchyName");
+							parentLocCode = entry.optString("parentLocCode", "");
+							break;
+						}
 					}
 				}
 


### PR DESCRIPTION
Fixing non English failure test cases by implementing the location data creation of primary language along with optional languages