### PR TITLE
MOSIP-36005 - Initializing the root variable in method level

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/MockSMTPListener.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/MockSMTPListener.java
@@ -55,8 +55,6 @@ public class MockSMTPListener {
 	}
 
 	private static class WebSocketClient implements WebSocket.Listener {
-		Long count = (long) 00;
-		Root root = new Root();
 
 		public WebSocketClient() {
 			return;
@@ -82,6 +80,7 @@ public class MockSMTPListener {
 				onClose(webSocket, 0, "After suite invoked closing");
 			}
 			try {
+				Root root = new Root();
 				ObjectMapper om = new ObjectMapper();
 				String message = "";
 				String address = "";


### PR DESCRIPTION
MOSIP-36005 - Initializing the root variable in method level