### PR TITLE
MOSIP-38434 - Disabled the debug logs by default and apitest common version updated

### DIFF
--- a/apitest-commons/src/main/resources/config/Kernel.properties
+++ b/apitest-commons/src/main/resources/config/Kernel.properties
@@ -220,7 +220,7 @@ ida_db_schema=ida
 
 
 #------------------------ Generic properties  ------------------------#
-enableDebug=yes
+enableDebug=no
 preconfiguredOtp=111111
 usePreConfiguredOtp=false
 # supported values yes or no. Assume that by Default e-signet is deployed


### PR DESCRIPTION
MOSIP-38434 - Disabled the debug logs by default and apitest commons version updated.