### PR TITLE
MOSIP-39126 - Make the module name pattern in the global methods class modifiable from all modules

### DIFF
--- a/apitest-commons/src/main/resources/config/Kernel.properties
+++ b/apitest-commons/src/main/resources/config/Kernel.properties
@@ -269,6 +269,8 @@ langselect=0
 #Uncommemnt the below to run in Docker
 authCertsPath=/home/mosip/authcerts
 
+# example of the value will be --> moduleNamePattern=(mimoto|certify|signup|partnermanager|preregistration|resident|residentmobileapp|masterdata|esignet|idgenerator|policymanager|idauthentication|idrepository|auditmanager|authmanager|keymanager|mock-identity-system)
+moduleNamePattern=
 
 mosip_components_base_urls=
 #auditmanager=api-internal.released.mosip.net;idrepository=api-internal.released.mosip.net;authmanager=api-internal.released.mosip.net;resident=api-internal.released.mosip.net;partnermanager=api-internal.released.mosip.net;idauthentication=api-internal.released.mosip.net;masterdata=api-internal.released.mosip.net;idgenerator=api-internal.released.mosip.net;policymanager=api-internal.released.mosip.net;preregistration=api-internal.released.mosip.net;keymanager=api-internal.released.mosip.net;mock-identity-system=api.released.mosip.net


### PR DESCRIPTION
Added the moduleNamePattern to the kernel properties, providing a centralized location to fetch the property for all modules