### PR TITLE
MOSIP-40516 - Enhancing YAML Loading and Test Efficiency

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -51,6 +51,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +85,7 @@ import org.testng.Assert;
 import org.testng.Reporter;
 import org.testng.SkipException;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.exceptions.JWTDecodeException;
@@ -2572,15 +2574,33 @@ public class AdminTestUtil extends BaseTestCase {
 	public Object[] getYmlTestData(String ymlPath) {
 		String testType = testLevel;
 		final ObjectMapper mapper = new ObjectMapper();
-		List<TestCaseDTO> testCaseDTOList = new LinkedList<TestCaseDTO>();
-		Map<String, Map<String, Map<String, String>>> scriptsMap = loadyaml(ymlPath);
+//		List<TestCaseDTO> testCaseDTOList = new LinkedList<TestCaseDTO>();
+		List<TestCaseDTO> testCaseDTOList = new ArrayList<>();
+
+//		Map<String, Map<String, Map<String, String>>> scriptsMap = loadyaml(ymlPath);
+		Map<String, Map<String, Map<String, String>>> scriptsMap = new LinkedHashMap<>(loadyaml(ymlPath));
+		
 		for (String key : scriptsMap.keySet()) {
-			Map<String, Map<String, String>> testCases = scriptsMap.get(key);
+//			Map<String, Map<String, String>> testCases = scriptsMap.get(key);
+			Map<String, Map<String, String>> testCases = new LinkedHashMap<>(scriptsMap.get(key));
+
+//			if (testType.equalsIgnoreCase("smoke")) {
+//				testCases = testCases.entrySet().stream()
+//						.filter(mapElement -> mapElement.getKey().toLowerCase().contains("smoke")).collect(Collectors
+//								.toMap(mapElement -> mapElement.getKey(), mapElement -> mapElement.getValue()));
+//			}
+			
 			if (testType.equalsIgnoreCase("smoke")) {
-				testCases = testCases.entrySet().stream()
-						.filter(mapElement -> mapElement.getKey().toLowerCase().contains("smoke")).collect(Collectors
-								.toMap(mapElement -> mapElement.getKey(), mapElement -> mapElement.getValue()));
-			}
+	            testCases = testCases.entrySet().stream()
+	                .filter(mapElement -> mapElement.getKey().toLowerCase().contains("smoke"))
+	                .collect(Collectors.toMap(
+	                    Map.Entry::getKey,
+	                    Map.Entry::getValue,
+	                    (e1, e2) -> e1, // Merge function (not used, just to satisfy Collectors.toMap)
+	                    LinkedHashMap::new // Preserve order
+	                ));
+	        }
+			
 			for (String testCase : testCases.keySet()) {
 				TestCaseDTO testCaseDTO = mapper.convertValue(testCases.get(testCase), TestCaseDTO.class);
 				testCaseDTO.setTestCaseName(testCase);
@@ -2599,8 +2619,13 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			inputStream = new FileInputStream(new File(getResourcePath() + path).getAbsoluteFile());
 			bufferedInput = new BufferedInputStream(inputStream, customBufferSize);
-			Yaml yaml = new Yaml();
-			scriptsMap = yaml.loadAs(bufferedInput, Map.class);
+//			Yaml yaml = new Yaml();
+//			scriptsMap = yaml.loadAs(bufferedInput, Map.class);
+			
+			// Force YAML to use LinkedHashMap
+	        Yaml yaml = new Yaml(new Constructor(LinkedHashMap.class));
+	        scriptsMap = yaml.loadAs(bufferedInput, LinkedHashMap.class);
+	        
 		} catch (Exception e) {
 			logger.error("Error loading YAML: " + e.getMessage());
 		} finally {


### PR DESCRIPTION
- Keeping YAML data in order: When loading YAML files, we use LinkedHashMap so that the order of items stays the same as in the file.
- Fixing test filtering issues: Smoke tests were giving results in a random order. We fixed it so they always appear in a consistent order.
- Better test case storage: Instead of using a slower way to store test cases, we switched to ArrayList, which is faster and more efficient.