### PR TITLE
INJICERT-944 - Added the pms schema value on kernel props

### DIFF
--- a/apitest-commons/src/main/resources/config/Kernel.properties
+++ b/apitest-commons/src/main/resources/config/Kernel.properties
@@ -99,6 +99,7 @@ hibernate.current_session_context_class=thread
 db-su-user=postgres
 master_db_schema=master
 ida_db_schema=ida
+pms_db_schema=pms
 
 
 #------------------------ Generic properties  ------------------------#


### PR DESCRIPTION
Added the pms schema value on kernel props as it is required to delete queries and it is common for inji-certify, esignet, signup modules