### PR TITLE
MOSIP-41082 - Fixed the charset issue while sending params as URL encoded in apitest commons library

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/RestClient.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/RestClient.java
@@ -1952,10 +1952,10 @@ public class RestClient {
 
 		if (ConfigManager.IsDebugEnabled()) {
 			postResponse = given().config(config.encoderConfig(encoderConfig)).relaxedHTTPSValidation().formParams(formData)
-					.contentType("application/x-www-form-urlencoded").log().all().when().post(url).then().extract().response();
+					.contentType("application/x-www-form-urlencoded; charset=utf-8").log().all().when().post(url).then().extract().response();
 		} else {
 			postResponse = given().config(config.encoderConfig(encoderConfig)).relaxedHTTPSValidation().formParams(formData)
-					.contentType("application/x-www-form-urlencoded").when().post(url).then().extract().response();
+					.contentType("application/x-www-form-urlencoded; charset=utf-8").when().post(url).then().extract().response();
 		}
 
 		return postResponse;


### PR DESCRIPTION
MOSIP-41082 - Fixed the charset issue while sending params as URL encoded in apitest commons library