### PR TITLE
MOSIP-31010

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Translator.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Translator.java
@@ -1,9 +1,10 @@
-
 package io.mosip.testrig.apirig.utils;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 
@@ -12,44 +13,52 @@ import com.ibm.icu.text.Transliterator;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 
 public class Translator {
-	static String IDlookupFile = "src/main/resource/config/lang-isocode-transid.csv";
-	private static final Logger logger = Logger.getLogger(Translator.class);
-	public static void main(String[] args) {
-		String text = "Mohandas Karamchand Ghandhi"; // Translated text: Hallo Welt!
-		logger.info("Text:" + text + ",Translated text: " + translate("heb", text));
-	}
 
-	static String getLanguageID(String langIsoCode) {
+    static String IDlookupFile = "src/main/resource/config/lang-isocode-transid.csv";
+    private static final Logger logger = Logger.getLogger(Translator.class);
 
-		String value = "Any-Any";
-		
-		String filename = BaseTestCase.getGlobalResourcePath() + "/"+"config/lang-isocode-transid.csv";
-		
-		try (BufferedReader br = new BufferedReader(new FileReader(filename))) {
+    private static Map<String, String> langIsoCodeCache = null;
+
+    public static void main(String[] args) {
+        String text = "Mohandas Karamchand Ghandhi";
+        logger.info("Text:" + text + ", Translated text: " + translate("heb", text));
+    }
+
+    static String getLanguageID(String langIsoCode) {
+        if (langIsoCodeCache == null) {
+            loadLanguageIDCache();
+        }
+
+        return langIsoCodeCache.getOrDefault(langIsoCode.toLowerCase(), "Any-Any");
+    }
+
+    private static synchronized void loadLanguageIDCache() {
+        if (langIsoCodeCache != null) return; 
+
+        langIsoCodeCache = new HashMap<>();
+        String filename = BaseTestCase.getGlobalResourcePath() + "/" + "config/lang-isocode-transid.csv";
+
+        try (BufferedReader br = new BufferedReader(new FileReader(filename))) {
             String line;
             while ((line = br.readLine()) != null) {
                 String[] rec = line.split(",");
-                
-                // Processing each record
-                if (rec.length >= 3 && rec[0].toLowerCase().equals(langIsoCode.toLowerCase())) {
-                	value = rec[2].trim();
-                    if (!value.equals("")) {
-                        System.out.println("Value found for translation: " + value);
-                        break;
+                if (rec.length >= 3) {
+                    String key = rec[0].trim().toLowerCase();
+                    String value = rec[2].trim();
+                    if (!value.isEmpty()) {
+                        langIsoCodeCache.put(key, value);
                     }
                 }
             }
+            logger.info("Language ID cache loaded with " + langIsoCodeCache.size() + " entries.");
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Error loading language ID CSV file: " + e.getMessage(), e);
         }
-		return value;
-	}
+    }
 
-	public static String translate(String toLanguageIsoCode, String text) {
-		
-		String lang_from_to = getLanguageID(toLanguageIsoCode);
-	
-		Transliterator toTrans = Transliterator.getInstance(lang_from_to);
-		return toTrans.transliterate(text);
-	}
+    public static String translate(String toLanguageIsoCode, String text) {
+        String lang_from_to = getLanguageID(toLanguageIsoCode);
+        Transliterator toTrans = Transliterator.getInstance(lang_from_to);
+        return toTrans.transliterate(text);
+    }
 }

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Translator.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Translator.java
@@ -1,6 +1,7 @@
 package io.mosip.testrig.apirig.utils;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
@@ -14,7 +15,6 @@ import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 
 public class Translator {
 
-    static String IDlookupFile = "src/main/resource/config/lang-isocode-transid.csv";
     private static final Logger logger = Logger.getLogger(Translator.class);
 
     private static Map<String, String> langIsoCodeCache = null;
@@ -36,7 +36,13 @@ public class Translator {
         if (langIsoCodeCache != null) return; 
 
         langIsoCodeCache = new HashMap<>();
-        String filename = BaseTestCase.getGlobalResourcePath() + "/" + "config/lang-isocode-transid.csv";
+        String filename = BaseTestCase.getGlobalResourcePath() + "/config/lang-isocode-transid.csv";
+        
+        File file = new File(filename);
+        if (!file.exists()) {
+        logger.error("Translation config file not found at path: " + filename);
+        return;
+        }
 
         try (BufferedReader br = new BufferedReader(new FileReader(filename))) {
             String line;

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Translator.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Translator.java
@@ -16,7 +16,9 @@ import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 public class Translator {
 
     private static final Logger logger = Logger.getLogger(Translator.class);
-
+    
+    // Map is used to store language codes and their matching translation IDs
+    // Avoid reading the file again and again
     private static Map<String, String> langIsoCodeCache = null;
 
     public static void main(String[] args) {
@@ -25,14 +27,18 @@ public class Translator {
     }
 
     static String getLanguageID(String langIsoCode) {
+    	// If the cache is empty, load the data from the file
         if (langIsoCodeCache == null) {
             loadLanguageIDCache();
         }
-
+        
+        // Return the translation ID for the given language code.
+        // If not found, return a default value.
         return langIsoCodeCache.getOrDefault(langIsoCode.toLowerCase(), "Any-Any");
     }
 
     private static synchronized void loadLanguageIDCache() {
+    	// If the cache is already loaded, do nothing
         if (langIsoCodeCache != null) return; 
 
         langIsoCodeCache = new HashMap<>();
@@ -43,8 +49,9 @@ public class Translator {
         logger.error("Translation config file not found at path: " + filename);
         return;
         }
-
-        try (BufferedReader br = new BufferedReader(new FileReader(filename))) {
+        
+        // Read data from the CSV file and put it into the cache
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
             String line;
             while ((line = br.readLine()) != null) {
                 String[] rec = line.split(",");
@@ -56,6 +63,8 @@ public class Translator {
                     }
                 }
             }
+            
+            // This message will be shown only once in the console when the cache is loaded for the first time.
             logger.info("Language ID cache loaded with " + langIsoCodeCache.size() + " entries.");
         } catch (IOException e) {
             logger.error("Error loading language ID CSV file: " + e.getMessage(), e);


### PR DESCRIPTION
Added caching to the getLanguageID() method in the Translator class to avoid reloading the lang-isocode-transid.csv file on every call.
This improves performance and reduces redundant file I/O, especially during MasterData suite runs.