### PR TITLE
MOSIP-40258: Checking for XSS-protection headers in response

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -6280,46 +6280,46 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	
-	public static boolean checkIsCertTrusted(String certIssuer, JSONArray ArrayOfJsonObjects, int recursiveCount) {
-		for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
-			if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject")
-					&& ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")
-					&& ArrayOfJsonObjects.getJSONObject(i).getString("certSubject").equals(certIssuer)) {
-
-				String certSubjectValue = ArrayOfJsonObjects.getJSONObject(i).getString("certSubject");
-				String certIssuerValue = ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer");
-
-				if (!(certSubjectValue.equals(certIssuerValue)) && recursiveCount <= 5) {
-					recursiveCount++;
-					return checkIsCertTrusted(certIssuerValue, ArrayOfJsonObjects, recursiveCount);
-				} else if (certSubjectValue.equals(certIssuerValue)) {
-					return true;
-				} else {
-					break;
-				}
-			}
-		}
-		return false;
-	}
-	
-	public static boolean IsCertTrusted(String certSubjectSubString) {
-		if (ArrayOfJsonObjects == null) {
-			ArrayOfJsonObjects = getSyncDataResponseArray();
-		}
-
-		if (ArrayOfJsonObjects != null) {
-			for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
-				if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject") && ArrayOfJsonObjects.getJSONObject(i)
-						.getString("certSubject").contains(certSubjectSubString)) {
-					if (ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")) {
-						return checkIsCertTrusted(ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer"),
-								ArrayOfJsonObjects, 1);
-					}
-				}
-			}
-		}
-		return false;
-	}
+//	public static boolean checkIsCertTrusted(String certIssuer, JSONArray ArrayOfJsonObjects, int recursiveCount) {
+//		for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
+//			if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject")
+//					&& ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")
+//					&& ArrayOfJsonObjects.getJSONObject(i).getString("certSubject").equals(certIssuer)) {
+//
+//				String certSubjectValue = ArrayOfJsonObjects.getJSONObject(i).getString("certSubject");
+//				String certIssuerValue = ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer");
+//
+//				if (!(certSubjectValue.equals(certIssuerValue)) && recursiveCount <= 5) {
+//					recursiveCount++;
+//					return checkIsCertTrusted(certIssuerValue, ArrayOfJsonObjects, recursiveCount);
+//				} else if (certSubjectValue.equals(certIssuerValue)) {
+//					return true;
+//				} else {
+//					break;
+//				}
+//			}
+//		}
+//		return false;
+//	}
+//	
+//	public static boolean IsCertTrusted(String certSubjectSubString) {
+//		if (ArrayOfJsonObjects == null) {
+//			ArrayOfJsonObjects = getSyncDataResponseArray();
+//		}
+//
+//		if (ArrayOfJsonObjects != null) {
+//			for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
+//				if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject") && ArrayOfJsonObjects.getJSONObject(i)
+//						.getString("certSubject").contains(certSubjectSubString)) {
+//					if (ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")) {
+//						return checkIsCertTrusted(ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer"),
+//								ArrayOfJsonObjects, 1);
+//					}
+//				}
+//			}
+//		}
+//		return false;
+//	}
    
    
    public static JSONArray getRequiredField()  {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -239,22 +239,23 @@ public class AdminTestUtil extends BaseTestCase {
 	 */
 
 	protected Response postWithBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName)throws SecurityXSSException {
 		return postWithBodyAndCookie(url, jsonInput, false, cookieName, role, testCaseName, false);
 	}
 
 	protected Response postWithBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, boolean bothAccessAndIdToken) {
+			String testCaseName, boolean bothAccessAndIdToken)throws SecurityXSSException {
 		return postWithBodyAndCookie(url, jsonInput, false, cookieName, role, testCaseName, bothAccessAndIdToken);
 	}
 
 	protected Response postWithBodyAndCookie(String url, String jsonInput, boolean auditLogCheck, String cookieName,
-			String role, String testCaseName) {
+			String role, String testCaseName)throws SecurityXSSException {
+		
 		return postWithBodyAndCookie(url, jsonInput, auditLogCheck, cookieName, role, testCaseName, false);
 	}
 	
 	protected Response postWithBodyAndCookie(String url, String jsonInput, boolean auditLogCheck, String cookieName,
-			String role, String testCaseName, boolean bothAccessAndIdToken) {
+			String role, String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -288,6 +289,8 @@ public class AdminTestUtil extends BaseTestCase {
 						MediaType.APPLICATION_JSON, cookieName, token);
 			}
 			
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);			
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (auditLogCheck) {
@@ -297,7 +300,10 @@ public class AdminTestUtil extends BaseTestCase {
 				checkDbAndValidate(timeStamp1, dbChecker);
 			}
 
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 
@@ -305,7 +311,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 	
 	protected Response deleteWithBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -315,15 +321,20 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.deleteRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
 	}
 
 	protected Response postWithBodyAndCookieWithText(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -333,16 +344,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON, "*/*", cookieName,
 					token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithBodyAndCookieWithoutBody(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 	
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
@@ -353,16 +369,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON, "*/*", cookieName,
 					token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postRequestWithCookieAuthHeaderAndXsrfToken(String url, String jsonInput, String cookieName,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		HashMap<String, String> headers = new HashMap<>();
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
@@ -441,13 +462,18 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.postRequestWithMultipleHeadersAndCookies(url, inputJson,
 						MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token, headers);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.contains("_STransId"))
 				getvalueFromResponseHeader(response, testCaseName);
 
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -490,7 +516,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response postWithBodyAndCookieAuthHeaderAndXsrfTokenForAutoGeneratedId(String url, String jsonInput,
-			String cookieName, String testCaseName, String idKeyName) {
+			String cookieName, String testCaseName, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		HashMap<String, String> headers = new HashMap<>();
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
@@ -512,13 +538,18 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithMultipleHeadersAndCookies(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -526,7 +557,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response postRequestWithCookieAuthHeaderAndXsrfTokenForAutoGenId(String url, String jsonInput,
-			String cookieName, String testCaseName, String idKeyName) {
+			String cookieName, String testCaseName, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		HashMap<String, String> headers = new HashMap<>();
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
@@ -589,6 +620,8 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.postRequestWithMultipleHeadersAndCookies(url, inputJson, MediaType.APPLICATION_JSON,
 						MediaType.APPLICATION_JSON, cookieName, token, headers);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
@@ -597,14 +630,17 @@ public class AdminTestUtil extends BaseTestCase {
 				getvalueFromResponseHeader(response, testCaseName);
 			}
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 	
 	protected Response getRequestWithCookieAuthHeaderAndXsrfToken(String url, String jsonInput, String cookieName,
-			String role, String testCaseName) {
+			String role, String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		HashMap<String, String> headers = new HashMap<>();
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
@@ -635,16 +671,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.getRequestWithMultipleHeadersAndCookies(url, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postRequestWithCookieAuthHeader(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		token = kernelAuthLib.getTokenByRole(role);
@@ -670,16 +711,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithMultipleHeadersWithoutCookie(url, inputJson,
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithBodyAndCookieForKeyCloak(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -689,16 +735,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithBearerToken(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithBodyAcceptTextPlainAndCookie(String url, String jsonInput, String cookieName,
-			String role, String testCaseName) {
+			String role, String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		token = kernelAuthLib.getTokenByRole(role);
@@ -707,16 +758,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.TEXT_PLAIN, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postRequestWithCookieAuthHeaderAndSignature(String url, String jsonInput, String cookieName,
-			String role, String testCaseName) {
+			String role, String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String[] uriParts = url.split("/");
 		String partnerId = uriParts[uriParts.length - 2];
@@ -735,16 +791,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithMultipleHeaders(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postRequestWithAuthHeaderAndSignatureForOtp(String url, String jsonInput, String cookieName,
-			String token, Map<String, String> headers, String testCaseName) {
+			String token, Map<String, String> headers, String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -754,9 +815,14 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithMultipleHeaders(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
@@ -764,7 +830,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response postRequestWithAuthHeaderAndSignatureForOtpAutoGenId(String url, String jsonInput,
-			String cookieName, String token, Map<String, String> headers, String testCaseName, String idKeyName) {
+			String cookieName, String token, Map<String, String> headers, String testCaseName, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -774,12 +840,17 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithMultipleHeaders(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
@@ -787,7 +858,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response patchRequestWithCookieAuthHeaderAndSignature(String url, String jsonInput, String cookieName,
-			String role, String testCaseName) {
+			String role, String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		HashMap<String, String> headers = new HashMap<>();
 		headers.put(AUTHORIZATHION_HEADERNAME, AUTH_HEADER_VALUE);
@@ -799,15 +870,20 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.patchRequestWithMultipleHeaders(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
-	protected Response postRequestWithAuthHeaderAndSignature(String url, String jsonInput, String testCaseName) {
+	protected Response postRequestWithAuthHeaderAndSignature(String url, String jsonInput, String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String[] uriParts = url.split("/");
 		String partnerId = uriParts[uriParts.length - 2];
@@ -826,9 +902,14 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithMultipleHeadersWithoutCookie(url, inputJson,
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -845,6 +926,8 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithMultipleHeadersWithoutCookie(url, inputJson,
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		} catch (Exception e) {
@@ -854,12 +937,12 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response postRequestWithCookieAndHeader(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName)throws SecurityXSSException {
 		return postRequestWithCookieAndHeader(url, jsonInput, cookieName, role, testCaseName, false);
 	}
 
 	protected Response postRequestWithCookieAndHeader(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, boolean bothAccessAndIdToken) {
+			String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		if (BaseTestCase.currentModule.equals(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.equals("auth")
@@ -886,16 +969,21 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.postRequestWithCookieAndHeader(url, inputJson, MediaType.APPLICATION_JSON,
 						MediaType.APPLICATION_JSON, cookieName, token, AUTHORIZATHION_HEADERNAME, AUTH_HEADER_VALUE);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response patchRequestWithCookieAndHeader(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		if (url.contains("ID:"))
 			url = inputJsonKeyWordHandeler(url, testCaseName);
@@ -909,21 +997,26 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.patchRequestWithCookieAndHeader(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token, AUTHORIZATHION_HEADERNAME, AUTH_HEADER_VALUE);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response patchWithBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		return patchWithBodyAndCookie(url, jsonInput, cookieName, role, testCaseName, false);
 	}
 
 	protected Response patchWithBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, boolean bothAccessAndIdToken) {
+			String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		if (url.contains("ID:")) {
 			url = uriKeyWordHandelerUri(url, testCaseName);
@@ -945,34 +1038,39 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.patchRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON,
 						MediaType.APPLICATION_JSON, cookieName, token);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithBodyAndCookieForAutoGeneratedId(String url, String jsonInput, boolean auditLogCheck,
-			String cookieName, String role, String testCaseName, String idKeyName) {
+			String cookieName, String role, String testCaseName, String idKeyName)throws SecurityXSSException {
 		return postWithBodyAndCookieForAutoGeneratedId(url, jsonInput, auditLogCheck, cookieName, role, testCaseName,
 				idKeyName, false);
 	}
 
 	protected Response postWithBodyAndCookieForAutoGeneratedId(String url, String jsonInput, String cookieName,
-			String role, String testCaseName, String idKeyName) {
+			String role, String testCaseName, String idKeyName)throws SecurityXSSException {
 		return postWithBodyAndCookieForAutoGeneratedId(url, jsonInput, false, cookieName, role, testCaseName, idKeyName,
 				false);
 	}
 
 	protected Response postWithBodyAndCookieForAutoGeneratedId(String url, String jsonInput, boolean auditLogCheck,
-			boolean bothAccessAndIdToken, String cookieName, String role, String testCaseName, String idKeyName) {
+			boolean bothAccessAndIdToken, String cookieName, String role, String testCaseName, String idKeyName)throws SecurityXSSException {
 		return postWithBodyAndCookieForAutoGeneratedId(url, jsonInput, false, cookieName, role, testCaseName, idKeyName,
 				bothAccessAndIdToken);
 	}
 
 	protected Response postWithBodyAndCookieForAutoGeneratedId(String url, String jsonInput, boolean auditLogCheck,
-			String cookieName, String role, String testCaseName, String idKeyName, boolean bothAccessAndIdToken) {
+			String cookieName, String role, String testCaseName, String idKeyName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 
@@ -1001,6 +1099,8 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.postRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON,
 						MediaType.APPLICATION_JSON, cookieName, token);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			if (auditLogCheck) {
 				JSONObject jsonObject = new JSONObject(inputJson);
@@ -1011,7 +1111,10 @@ public class AdminTestUtil extends BaseTestCase {
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 
@@ -1019,7 +1122,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response postWithBodyAndBearerTokenForAutoGeneratedId(String url, String jsonInput, String cookieName,
-			String role, String testCaseName, String idKeyName) {
+			String role, String testCaseName, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		if (testCaseName.contains("Invalid_Token")) {
@@ -1034,6 +1137,8 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postRequestWithBearerToken(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.toLowerCase().contains("_sid")) {
@@ -1041,14 +1146,17 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithBodyAndCookieForAutoGeneratedIdForUrlEncoded(String url, String jsonInput,
-			String testCaseName, String idKeyName) {
+			String testCaseName, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		ObjectMapper mapper = new ObjectMapper();
@@ -1059,6 +1167,8 @@ public class AdminTestUtil extends BaseTestCase {
 			logger.info(inputJson);
 			GlobalMethods.reportRequest(null, inputJson, url);
 			response = RestClient.postRequestWithFormDataBody(url, map);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.toLowerCase().contains("_sid")) {
@@ -1075,14 +1185,17 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response patchWithBodyAndCookieWithAutoGeneratedId(String url, String jsonInput, String cookieName,
-			String role, String testCaseName, String idKeyName) {
+			String role, String testCaseName, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		if (url.contains("ID:")) {
 			url = uriKeyWordHandelerUri(url, testCaseName);
@@ -1094,19 +1207,24 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.patchRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response patchWithBodyAndCookieForAutoGeneratedId(String url, String jsonInput, String cookieName,
-			String role, String testCaseName, String idKeyName) {
+			String role, String testCaseName, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		token = kernelAuthLib.getTokenByRole(role);
@@ -1115,6 +1233,8 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.patchRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.toLowerCase().contains("_sid")) {
@@ -1122,32 +1242,35 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response getWithPathParamAndCookieForAutoGeneratedId(String url, String jsonInput, String cookieName,
-			String role, String testCaseName, String idKeyName) {
+			String role, String testCaseName, String idKeyName) throws SecurityXSSException{
 		return getWithPathParamAndCookieForAutoGeneratedId(url, jsonInput, false, cookieName, role, testCaseName,
 				idKeyName, false);
 	}
 
 	protected Response getWithPathParamAndCookieForAutoGeneratedId(String url, String jsonInput, String cookieName,
-			String role, String testCaseName, String idKeyName, boolean bothAccessAndIdToken) {
+			String role, String testCaseName, String idKeyName, boolean bothAccessAndIdToken) throws SecurityXSSException{
 		return getWithPathParamAndCookieForAutoGeneratedId(url, jsonInput, false, cookieName, role, testCaseName,
 				idKeyName, bothAccessAndIdToken);
 	}
 
 	protected Response getWithPathParamAndCookieForAutoGeneratedId(String url, String jsonInput, boolean auditLogCheck,
-			String cookieName, String role, String testCaseName, String idKeyName) {
+			String cookieName, String role, String testCaseName, String idKeyName)throws SecurityXSSException {
 		return getWithPathParamAndCookieForAutoGeneratedId(url, jsonInput, auditLogCheck, cookieName, role,
 				testCaseName, idKeyName, false);
 	}
 
 	protected Response getWithPathParamAndCookieForAutoGeneratedId(String url, String jsonInput, boolean auditLogCheck,
-			String cookieName, String role, String testCaseName, String idKeyName, boolean bothAccessAndIdToken) {
+			String cookieName, String role, String testCaseName, String idKeyName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -1195,6 +1318,8 @@ public class AdminTestUtil extends BaseTestCase {
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (auditLogCheck) {
@@ -1204,7 +1329,10 @@ public class AdminTestUtil extends BaseTestCase {
 				checkDbAndValidate(timeStamp1, dbChecker);
 			}
 
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
@@ -1224,7 +1352,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response postWithFormPathParamAndFile(String url, String jsonInput, String role, String testCaseName,
-			String idKeyName) {
+			String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		JSONObject req = new JSONObject(inputJson);
@@ -1260,25 +1388,30 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithFormPathParamAndFile(url, formParams, pathParams, filetoUpload, fileKeyName,
 					MediaType.MULTIPART_FORM_DATA, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithParamAndFile(String url, String jsonInput, String role, String testCaseName,
-			String idKeyName) {
+			String idKeyName)throws SecurityXSSException {
 		return postWithParamAndFile(url, jsonInput, role, testCaseName, idKeyName, false);
 	}
 
 	protected Response postWithParamAndFile(String url, String jsonInput, String role, String testCaseName,
-			String idKeyName, boolean bothAccessAndIdToken) {
+			String idKeyName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		JSONObject req = new JSONObject(inputJson);
@@ -1318,20 +1451,25 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.postWithParamsAndFile(url, map, filetoUpload, fileKeyName,
 						MediaType.MULTIPART_FORM_DATA, token);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithFormDataAndFile(String url, String jsonInput, String role, String testCaseName,
-			String idKeyName) {
+			String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 
@@ -1353,20 +1491,25 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithFormDataAndFile(url, formParams, absolueFilePath,
 					MediaType.MULTIPART_FORM_DATA, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithMultipartFormDataAndFile(String url, String jsonInput, String role, String testCaseName,
-			String idKeyName) {
+			String idKeyName) throws SecurityXSSException {
 		Response response = null;
 
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
@@ -1391,20 +1534,25 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithMultipartFormDataAndFile(url, formParams, MediaType.MULTIPART_FORM_DATA,
 					token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithFormDataAndMultipleFile(String url, String jsonInput, String role, String testCaseName,
-			String idKeyName) {
+			String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 
@@ -1447,19 +1595,24 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithFormDataAndMultipleFile(url, formParams, listFiles,
 					MediaType.MULTIPART_FORM_DATA, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
-	public static void initialUserCreation() {
+	public static void initialUserCreation() throws SecurityXSSException {
 		Response response = null;
 		String token = kernelAuthLib.getTokenByRole(GlobalConstants.ADMIN);
 		org.json.simple.JSONObject actualRequestGeneration = BaseTestCase.getRequestJson("config/bulkUpload.json");
@@ -1503,9 +1656,14 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithFormDataAndMultipleFile(url, formParams, listFiles,
 					MediaType.MULTIPART_FORM_DATA, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
-		} catch (Exception e) {
+		} catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 
@@ -1522,12 +1680,12 @@ public class AdminTestUtil extends BaseTestCase {
 	 */
 
 	protected Response putWithBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName)throws SecurityXSSException {
 		return putWithBodyAndCookie(url, jsonInput, cookieName, role, testCaseName, false);
 	}
 
 	protected Response putWithBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, boolean bothAccessAndIdToken) {
+			String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		if (bothAccessAndIdToken) {
@@ -1546,16 +1704,21 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.putRequestWithCookie(url, inputJson, MediaType.APPLICATION_JSON,
 						MediaType.APPLICATION_JSON, cookieName, token);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response putWithPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -1572,16 +1735,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.putRequestWithParm(url, map, MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON,
 					cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response patchWithPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -1598,16 +1766,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.patchRequestWithParm(url, map, MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON,
 					cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response putWithPathParamsBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, String pathParams) {
+			String testCaseName, String pathParams) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		logger.info("inputJson is::" + inputJson);
@@ -1633,16 +1806,21 @@ public class AdminTestUtil extends BaseTestCase {
 				pathParamsMap.put("id", idField);
 			response = RestClient.putWithPathParamsBodyAndCookie(url, pathParamsMap, req.toString(),
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response putWithPathParamsBodyAndBearerToken(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, String pathParams) {
+			String testCaseName, String pathParams) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		logger.info("inputJson is::" + inputJson);
@@ -1671,16 +1849,21 @@ public class AdminTestUtil extends BaseTestCase {
 				pathParamsMap.put("id", idField);
 			response = RestClient.putWithPathParamsBodyAndBearerToken(url, pathParamsMap, req.toString(),
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithPathParamsBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, String pathParams) {
+			String testCaseName, String pathParams) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -1701,9 +1884,14 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithPathParamsBodyAndCookie(url, pathParamsMap, req.toString(),
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1711,7 +1899,7 @@ public class AdminTestUtil extends BaseTestCase {
 	
 	
 	protected Response postWithPathParamsBodyAndCookieForAutoGeneratedId(String url, String jsonInput,
-			String cookieName, String role, String testCaseName, String pathParams, String idKeyName) {
+			String cookieName, String role, String testCaseName, String pathParams, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -1732,19 +1920,24 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithPathParamsBodyAndCookie(url, pathParamsMap, req.toString(),
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
 	}
 
 	protected Response postWithPathParamsBodyHeaderAndCookie(String url, String jsonInput, String cookieName,
-			String role, String testCaseName, String pathParams) {
+			String role, String testCaseName, String pathParams) throws SecurityXSSException {
 		Response response = null;
 		String signature = null;
 		HashMap<String, String> headers = new HashMap<>();
@@ -1785,16 +1978,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithPathParamsBodyHeadersAndCookie(url, pathParamsMap, inputJson,
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token, headers);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithQueryParamsBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, String queryParams, String idKeyName) {
+			String testCaseName, String queryParams, String idKeyName) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -1815,19 +2013,24 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.postWithQueryParamsBodyAndCookie(url, queryParamsMap, req.toString(),
 					MediaType.APPLICATION_JSON, "*/*", cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			if (testCaseName.toLowerCase().contains("_sid")) {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response patchWithPathParamsBodyAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, String pathParams) {
+			String testCaseName, String pathParams) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		JSONObject req = new JSONObject(inputJson);
@@ -1847,9 +2050,14 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.patchWithPathParamsBodyAndCookie(url, pathParamsMap, req.toString(),
 					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1866,22 +2074,22 @@ public class AdminTestUtil extends BaseTestCase {
 	 */
 
 	protected Response getWithPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName)throws SecurityXSSException {
 		return getWithPathParamAndCookie(url, jsonInput, false, cookieName, role, testCaseName, false);
 	}
 
 	protected Response getWithPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, boolean bothAccessAndIdToken) {
+			String testCaseName, boolean bothAccessAndIdToken)throws SecurityXSSException {
 		return getWithPathParamAndCookie(url, jsonInput, false, cookieName, role, testCaseName, bothAccessAndIdToken);
 	}
 
 	protected Response getWithPathParamAndCookie(String url, String jsonInput, boolean auditLogCheck, String cookieName,
-			String role, String testCaseName) {
+			String role, String testCaseName)throws SecurityXSSException {
 		return getWithPathParamAndCookie(url, jsonInput, auditLogCheck, cookieName, role, testCaseName, false);
 	}
 
 	protected Response getWithPathParamAndCookie(String url, String jsonInput, boolean auditLogCheck, String cookieName,
-			String role, String testCaseName, boolean bothAccessAndIdToken) {
+			String role, String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -1967,21 +2175,26 @@ public class AdminTestUtil extends BaseTestCase {
 					checkDbAndValidate(timeStamp1, dbChecker);
 				}
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
 	}
 
 	protected Response deleteWithPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName)throws SecurityXSSException {
 		return deleteWithPathParamAndCookie(url, jsonInput, cookieName, role, testCaseName, false);
 	}
 
 	protected Response deleteWithPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, boolean bothAccessAndIdToken) {
+			String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -2011,17 +2224,22 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.deleteRequestWithCookieAndPathParm(url, map, MediaType.APPLICATION_JSON,
 						MediaType.APPLICATION_JSON, cookieName, token);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response deleteWithPathParamAndCookieForKeyCloak(String url, String jsonInput, String cookieName,
-			String role, String testCaseName) {
+			String role, String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
@@ -2041,10 +2259,15 @@ public class AdminTestUtil extends BaseTestCase {
 
 			response = RestClient.deleteRequestWithCookieAndPathParmForKeyCloak(url, map, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -2222,7 +2445,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response getWithQueryParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -2240,16 +2463,21 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.getRequestWithCookieAndQueryParm(url, map, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e.getMessage());
 			return response;
 		}
 	}
 
 	protected Response patchWithQueryParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -2267,9 +2495,14 @@ public class AdminTestUtil extends BaseTestCase {
 		try {
 			response = RestClient.patchRequestWithCookieAndQueryParm(url, map, MediaType.APPLICATION_JSON,
 					MediaType.APPLICATION_JSON, cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e.getMessage());
 			return response;
 		}
@@ -3515,12 +3748,12 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	protected Response postWithOnlyPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException{
 		return postWithOnlyPathParamAndCookie(url, jsonInput, cookieName, role, testCaseName, false);
 	}
 
 	protected Response postWithOnlyPathParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName, boolean bothAccessAndIdToken) {
+			String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -3548,16 +3781,21 @@ public class AdminTestUtil extends BaseTestCase {
 				response = RestClient.postRequestWithCookieAndOnlyPathParm(url, map, MediaType.APPLICATION_JSON,
 						MediaType.APPLICATION_JSON, cookieName, token);
 			}
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postWithOnlyQueryParamAndCookie(String url, String jsonInput, String cookieName, String role,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		jsonInput = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		HashMap<String, String> map = null;
@@ -3574,8 +3812,13 @@ public class AdminTestUtil extends BaseTestCase {
 		GlobalMethods.reportRequest(null, jsonInput, url);
 		try {
 			response = RestClient.postRequestWithQueryParm(url, map, "*/*", "*/*", cookieName, token);
+			//check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+	        // Let SecurityException bubble up as expected
+	        throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -301,9 +301,11 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 
@@ -325,8 +327,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
@@ -349,8 +353,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -374,8 +380,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -471,8 +479,10 @@ public class AdminTestUtil extends BaseTestCase {
 
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -547,8 +557,10 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -631,8 +643,10 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -676,8 +690,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -716,9 +732,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -740,9 +758,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -763,9 +783,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -796,8 +818,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -820,9 +844,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
@@ -848,8 +874,10 @@ public class AdminTestUtil extends BaseTestCase {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
@@ -875,8 +903,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -907,16 +937,18 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
 	}
 
 	protected Response postRequestWithHeaderAndSignature(String url, String jsonInput, String signature,
-			String testCaseName) {
+			String testCaseName) throws SecurityXSSException {
 		Response response = null;
 		HashMap<String, String> headers = new HashMap<>();
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
@@ -930,7 +962,12 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		} catch (Exception e) {
+		}catch (SecurityXSSException se) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -973,10 +1010,12 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
-		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+		} catch (SecurityXSSException se) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1002,8 +1041,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1043,8 +1084,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1112,9 +1155,11 @@ public class AdminTestUtil extends BaseTestCase {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 
@@ -1147,8 +1192,10 @@ public class AdminTestUtil extends BaseTestCase {
 
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1186,9 +1233,11 @@ public class AdminTestUtil extends BaseTestCase {
 
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1215,8 +1264,10 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1243,8 +1294,10 @@ public class AdminTestUtil extends BaseTestCase {
 
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1330,8 +1383,10 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
@@ -1397,9 +1452,11 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1460,8 +1517,10 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1500,9 +1559,11 @@ public class AdminTestUtil extends BaseTestCase {
 
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1543,9 +1604,11 @@ public class AdminTestUtil extends BaseTestCase {
 
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1604,8 +1667,10 @@ public class AdminTestUtil extends BaseTestCase {
 
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1661,8 +1726,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 		} catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
@@ -1709,8 +1776,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1740,9 +1809,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1771,9 +1842,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1811,9 +1884,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -1854,8 +1929,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1889,8 +1966,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -1928,8 +2007,10 @@ public class AdminTestUtil extends BaseTestCase {
 				writeAutoGeneratedId(response, idKeyName, testCaseName);
 			}
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
@@ -1983,8 +2064,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -2021,8 +2104,10 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -2055,8 +2140,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
@@ -2180,9 +2267,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
@@ -2230,9 +2319,11 @@ public class AdminTestUtil extends BaseTestCase {
 			return response;
 
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -2265,9 +2356,11 @@ public class AdminTestUtil extends BaseTestCase {
 			return response;
 
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -2468,9 +2561,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e.getMessage());
 			return response;
 		}
@@ -2500,8 +2595,10 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
 	    } catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e.getMessage());
 			return response;
@@ -3786,9 +3883,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 			return response;
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 			return response;
 		}
@@ -3816,9 +3915,11 @@ public class AdminTestUtil extends BaseTestCase {
 			GlobalMethods.checkXSSProtectionHeader(response, url);	
 			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
 		}catch (SecurityXSSException se) {
-	        // Let SecurityException bubble up as expected
-	        throw se;
-	    } catch (Exception e) {
+			String responseHeadersString = (response == null) ? "No response" : response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString + "\nError: " + se.getMessage();
+		    logger.error(errorMessageString, se);
+		    throw se;
+	    }catch (Exception e) {
 			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
 		}
 		return response;
@@ -6179,46 +6280,46 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	
-//	public static boolean checkIsCertTrusted(String certIssuer, JSONArray ArrayOfJsonObjects, int recursiveCount) {
-//		for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
-//			if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject")
-//					&& ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")
-//					&& ArrayOfJsonObjects.getJSONObject(i).getString("certSubject").equals(certIssuer)) {
-//
-//				String certSubjectValue = ArrayOfJsonObjects.getJSONObject(i).getString("certSubject");
-//				String certIssuerValue = ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer");
-//
-//				if (!(certSubjectValue.equals(certIssuerValue)) && recursiveCount <= 5) {
-//					recursiveCount++;
-//					return checkIsCertTrusted(certIssuerValue, ArrayOfJsonObjects, recursiveCount);
-//				} else if (certSubjectValue.equals(certIssuerValue)) {
-//					return true;
-//				} else {
-//					break;
-//				}
-//			}
-//		}
-//		return false;
-//	}
-//	
-//	public static boolean IsCertTrusted(String certSubjectSubString) {
-//		if (ArrayOfJsonObjects == null) {
-//			ArrayOfJsonObjects = getSyncDataResponseArray();
-//		}
-//
-//		if (ArrayOfJsonObjects != null) {
-//			for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
-//				if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject") && ArrayOfJsonObjects.getJSONObject(i)
-//						.getString("certSubject").contains(certSubjectSubString)) {
-//					if (ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")) {
-//						return checkIsCertTrusted(ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer"),
-//								ArrayOfJsonObjects, 1);
-//					}
-//				}
-//			}
-//		}
-//		return false;
-//	}
+	public static boolean checkIsCertTrusted(String certIssuer, JSONArray ArrayOfJsonObjects, int recursiveCount) {
+		for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
+			if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject")
+					&& ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")
+					&& ArrayOfJsonObjects.getJSONObject(i).getString("certSubject").equals(certIssuer)) {
+
+				String certSubjectValue = ArrayOfJsonObjects.getJSONObject(i).getString("certSubject");
+				String certIssuerValue = ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer");
+
+				if (!(certSubjectValue.equals(certIssuerValue)) && recursiveCount <= 5) {
+					recursiveCount++;
+					return checkIsCertTrusted(certIssuerValue, ArrayOfJsonObjects, recursiveCount);
+				} else if (certSubjectValue.equals(certIssuerValue)) {
+					return true;
+				} else {
+					break;
+				}
+			}
+		}
+		return false;
+	}
+	
+	public static boolean IsCertTrusted(String certSubjectSubString) {
+		if (ArrayOfJsonObjects == null) {
+			ArrayOfJsonObjects = getSyncDataResponseArray();
+		}
+
+		if (ArrayOfJsonObjects != null) {
+			for (int i = 0; i < ArrayOfJsonObjects.length(); i++) {
+				if (ArrayOfJsonObjects.getJSONObject(i).has("certSubject") && ArrayOfJsonObjects.getJSONObject(i)
+						.getString("certSubject").contains(certSubjectSubString)) {
+					if (ArrayOfJsonObjects.getJSONObject(i).has("certIssuer")) {
+						return checkIsCertTrusted(ArrayOfJsonObjects.getJSONObject(i).getString("certIssuer"),
+								ArrayOfJsonObjects, 1);
+					}
+				}
+			}
+		}
+		return false;
+	}
    
    
    public static JSONArray getRequiredField()  {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
@@ -39,6 +39,18 @@ public class GlobalMethods {
 		return ConfigManager.getproperty("xssProtectionCheck").equalsIgnoreCase("yes") ? true : false;
 	}
 	
+	//Method to check if X-XSS-Protection is enabled or not
+	public static void checkXSSProtectionHeader(Response response, String url) throws SecurityXSSException {
+        String xssHeader = response.getHeader("X-Xss-Protection");
+
+        if (isXSSProtectionCheckEnabled() && 
+            (xssHeader == null || !xssHeader.equalsIgnoreCase("1; mode=block"))) {
+
+            reportResponseHeader(response.getHeaders().asList().toString(), url);
+            throw new SecurityXSSException("Response Header does not have X-XSS-Protection");
+        }
+    }
+	
 	// Method to set the module name and recompile the regex patterns
 	public static void setModuleNameAndReCompilePattern(String value) {
 		if (value == null || value.trim().isEmpty()) {
@@ -266,6 +278,12 @@ public class GlobalMethods {
 
 		Reporter.log(GlobalConstants.REPORT_RESPONSE_PREFIX + GlobalConstants.REPORT_RESPONSE_BODY + formattedHeader
 				+ ReportUtil.getTextAreaJsonMsgHtml(response.asString()) + GlobalConstants.REPORT_RESPONSE_SUFFIX);
+	}
+	public static void reportResponseHeader(String responseHeader, String url) {
+		String formattedHeader = ReportUtil.getTextAreaForHeaders(responseHeader);
+
+		Reporter.log(GlobalConstants.REPORT_RESPONSE_PREFIX + GlobalConstants.REPORT_RESPONSE_BODY + formattedHeader
+				 + GlobalConstants.REPORT_RESPONSE_SUFFIX);
 	}
 
 	public static void reportResponse(String responseHeader, String url, String response) {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SecurityXSSException.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SecurityXSSException.java
@@ -1,0 +1,14 @@
+package io.mosip.testrig.apirig.utils;
+
+public class SecurityXSSException extends Exception {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 3940520511435413848L;
+
+	public SecurityXSSException(String exp) {
+		super(exp);
+	}
+
+}

--- a/apitest-commons/src/main/resources/config/Kernel.properties
+++ b/apitest-commons/src/main/resources/config/Kernel.properties
@@ -104,7 +104,7 @@ pms_db_schema=pms
 
 
 #------------------------ Generic properties  ------------------------#
-
+preconfiguredOtp=111111
 # supported values yes or no. Assume that by Default e-signet is deployed
 eSignetDeployed=yes
 partnerUrlSuffix=
@@ -209,12 +209,12 @@ mosip_crvs1_client_secret =
 
 
 #-------- Generic Configuration ----------#
-preconfiguredOtp=111111
+
 # Enable or disable debugging mode (yes/no).
 enableDebug = no
 
 # Whether to use pre-configured OTP (true/false).
-usePreConfiguredOtp=true
+usePreConfiguredOtp = false
 
 # Mock Notification Channels (email/phone/email,phone).
 mockNotificationChannel = email,phone

--- a/apitest-commons/src/main/resources/config/Kernel.properties
+++ b/apitest-commons/src/main/resources/config/Kernel.properties
@@ -209,12 +209,12 @@ mosip_crvs1_client_secret =
 
 
 #-------- Generic Configuration ----------#
-
+preconfiguredOtp=111111
 # Enable or disable debugging mode (yes/no).
 enableDebug = no
 
 # Whether to use pre-configured OTP (true/false).
-
+usePreConfiguredOtp=true
 
 # Mock Notification Channels (email/phone/email,phone).
 mockNotificationChannel = email,phone

--- a/apitest-commons/src/main/resources/config/Kernel.properties
+++ b/apitest-commons/src/main/resources/config/Kernel.properties
@@ -104,7 +104,7 @@ pms_db_schema=pms
 
 
 #------------------------ Generic properties  ------------------------#
-preconfiguredOtp=111111
+
 # supported values yes or no. Assume that by Default e-signet is deployed
 eSignetDeployed=yes
 partnerUrlSuffix=
@@ -214,7 +214,7 @@ mosip_crvs1_client_secret =
 enableDebug = no
 
 # Whether to use pre-configured OTP (true/false).
-usePreConfiguredOtp = false
+
 
 # Mock Notification Channels (email/phone/email,phone).
 mockNotificationChannel = email,phone


### PR DESCRIPTION
API - check for XSS-protection headers in response
Added a check to validate the presence of the X-XSS-Protection header in API responses to ensure XSS protection is enabled and set to mode=block. This helps improve application security by mitigating potential cross-site scripting attacks.