### PR TITLE
MOSIP-40654 Resident api test rig should terminate after 1.5 hour

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Watchdog.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Watchdog.java
@@ -1,6 +1,11 @@
 package io.mosip.testrig.apirig.utils;
 
+
+import org.apache.log4j.Logger;
+
 public class Watchdog {
+	private static final Logger LOGGER = Logger.getLogger(ConfigManager.class);
+	
 	private final long timeoutMillis;
     private Thread watchdogThread;
     private boolean running = false;
@@ -15,10 +20,10 @@ public class Watchdog {
         watchdogThread = new Thread(() -> {
             try {
                 Thread.sleep(timeoutMillis);
-                System.err.println("Watchdog timeout exceeded. Terminating the application.");
+                LOGGER.error("Watchdog timeout exceeded. Terminating the application.");
                 System.exit(1); // Forcefully terminate after timeout
             } catch (InterruptedException e) {
-                System.out.println("Watchdog interrupted before timeout.");
+            	LOGGER.info("Watchdog interrupted before timeout.");
             }
         });
         watchdogThread.setDaemon(true); // Allows JVM to exit if main ends early

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Watchdog.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Watchdog.java
@@ -1,0 +1,36 @@
+package io.mosip.testrig.apirig.utils;
+
+public class Watchdog {
+	private final long timeoutMillis;
+    private Thread watchdogThread;
+    private boolean running = false;
+
+    public Watchdog(long timeoutMillis) {
+        this.timeoutMillis = timeoutMillis;
+    }
+
+    public void start() {
+        if (running) return;
+        running = true;
+        watchdogThread = new Thread(() -> {
+            try {
+                Thread.sleep(timeoutMillis);
+                System.err.println("Watchdog timeout exceeded. Terminating the application.");
+                System.exit(1); // Forcefully terminate after timeout
+            } catch (InterruptedException e) {
+                System.out.println("Watchdog interrupted before timeout.");
+            }
+        });
+        watchdogThread.setDaemon(true); // Allows JVM to exit if main ends early
+        watchdogThread.start();
+    }
+
+    public void stop() {
+        if (watchdogThread != null && watchdogThread.isAlive()) {
+            watchdogThread.interrupt(); // Cancel the watchdog
+            running = false;
+        }
+    }
+
+
+}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Watchdog.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Watchdog.java
@@ -1,41 +1,40 @@
 package io.mosip.testrig.apirig.utils;
 
-
 import org.apache.log4j.Logger;
 
 public class Watchdog {
 	private static final Logger LOGGER = Logger.getLogger(ConfigManager.class);
-	
+
 	private final long timeoutMillis;
-    private Thread watchdogThread;
-    private boolean running = false;
+	private Thread watchdogThread;
+	private boolean running = false;
 
-    public Watchdog(long timeoutMillis) {
-        this.timeoutMillis = timeoutMillis;
-    }
+	public Watchdog(long timeoutMillis) {
+		this.timeoutMillis = timeoutMillis;
+	}
 
-    public void start() {
-        if (running) return;
-        running = true;
-        watchdogThread = new Thread(() -> {
-            try {
-                Thread.sleep(timeoutMillis);
-                LOGGER.error("Watchdog timeout exceeded. Terminating the application.");
-                System.exit(1); // Forcefully terminate after timeout
-            } catch (InterruptedException e) {
-            	LOGGER.info("Watchdog interrupted before timeout.");
-            }
-        });
-        watchdogThread.setDaemon(true); // Allows JVM to exit if main ends early
-        watchdogThread.start();
-    }
+	public void start() {
+		if (running)
+			return;
+		running = true;
+		watchdogThread = new Thread(() -> {
+			try {
+				Thread.sleep(timeoutMillis);
+				LOGGER.error("Watchdog timeout exceeded. Terminating the application.");
+				System.exit(1); // Forcefully terminate after timeout
+			} catch (InterruptedException e) {
+				LOGGER.info("Watchdog interrupted before timeout.");
+			}
+		});
+		watchdogThread.setDaemon(true); // Allows JVM to exit if main ends early
+		watchdogThread.start();
+	}
 
-    public void stop() {
-        if (watchdogThread != null && watchdogThread.isAlive()) {
-            watchdogThread.interrupt(); // Cancel the watchdog
-            running = false;
-        }
-    }
-
+	public void stop() {
+		if (watchdogThread != null && watchdogThread.isAlive()) {
+			watchdogThread.interrupt(); // Cancel the watchdog
+			running = false;
+		}
+	}
 
 }


### PR DESCRIPTION
Added a Watchdog utility class in the commons module to enforce a maximum execution time for the Resident API Test Rig. Integrated the watchdog into MosipTestRunner.java to automatically terminate the test run after a fixed timeout (configurable, default set to 1 hours) to avoid unnecessary load on the environment in case of failures or hanging tests.