### PR TITLE
MOSIP-28246: API - Removed unused local variables

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/BiometricDataProvider.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/BiometricDataProvider.java
@@ -101,9 +101,9 @@ public class BiometricDataProvider {
 	private static final String LEFTEYE = "leftEye";
 	private static final String RIGHTEYE = "rightEye";
 	private static final String RIGHT = "Right";
-	private static final String MOUNTPATH = "mountPath";
-	private static final String DIRPATH = "dirPath ";
-	private static final String SCENARIO = "scenario";
+//	private static final String MOUNTPATH = "mountPath";
+//	private static final String DIRPATH = "dirPath ";
+//	private static final String SCENARIO = "scenario";
 	private static HashMap<String, String> biometricDataMap = new HashMap();
 	
 	
@@ -134,7 +134,7 @@ public class BiometricDataProvider {
 	
 	public static Boolean generateBiometricTestData(String mdsMode) throws Exception {
 		ResidentBiometricModel resident = new ResidentBiometricModel();
-		String cbeff = null;
+//		String cbeff = null;
 		MDSRCaptureModel capture = BiometricDataProvider.regenBiometricViaMDS(resident, mdsMode, 70);
 		if (capture == null) {
 			logger.error("Failed to generate biometric via mds");
@@ -347,17 +347,17 @@ public class BiometricDataProvider {
 
 	public static MDSRCaptureModel regenBiometricViaMDS(ResidentBiometricModel resident, String mdsMode, int qualityScore)
 			throws Exception {
-		BiometricDataModel biodata = null;
+//		BiometricDataModel biodata = null;
 		MDSRCaptureModel capture = null;
 		String contextKey = "default";
 		MDSClientInterface mds = null;
-		String val;
-		String mdsprofilePath = null;
-		String profileName = null;
+//		String val;
+//		String mdsprofilePath = null;
+//		String profileName = null;
 		int port = 0;
-		List<String> filteredAttribs = resident.getFilteredBioAttribtures();
-		List<BioModality> bioExceptions = resident.getBioExceptions();
-		List<String> bioexceptionlist = new ArrayList<String>();
+//		List<String> filteredAttribs = resident.getFilteredBioAttribtures();
+//		List<BioModality> bioExceptions = resident.getBioExceptions();
+//		List<String> bioexceptionlist = new ArrayList<String>();
 
 		try {
 			
@@ -468,7 +468,7 @@ public class BiometricDataProvider {
 
 		String retXml = "";
 
-		String mosipVersion = "1.2.1-SNAPSHOT";
+//		String mosipVersion = "1.2.1-SNAPSHOT";
 
 		XMLBuilder builder = XMLBuilder.create("BIR").a(XMLNS, "http://standards.iso.org/iso-iec/19785/-3/ed-2/")
 				.e(BIRINFO).e(INTEGRITY).t(FALSE).up().up();

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/mds/HttpRCapture.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/mds/HttpRCapture.java
@@ -2,11 +2,11 @@ package io.mosip.testrig.apirig.dataprovider.mds;
 import java.net.URI;
 
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
 
 public class HttpRCapture extends HttpEntityEnclosingRequestBase{
-private static final Logger logger = LoggerFactory.getLogger(HttpRCapture.class);
+//private static final Logger logger = LoggerFactory.getLogger(HttpRCapture.class);
 
 	    String METHOD_NAME ;
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/mds/MDSClient.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/mds/MDSClient.java
@@ -38,14 +38,14 @@ public class MDSClient implements MDSClientInterface {
 
 	public void setProfile(String profile, int port, String contextKey) {
 
-		String url = MDSURL + port + "/admin/profile";
+//		String url = MDSURL + port + "/admin/profile";
 		JSONObject body = new JSONObject();
 		body.put("profileId", profile);
 		body.put("type", "Biometric Device");
 
 		try {
 			logger.info("Inside Setprofile");
-			Response response = RestClient.post(url, body.toString());
+//			Response response = RestClient.post(url, body.toString());
 		} catch (Exception ex) {
 			logger.error(ex.getMessage());
 		}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/models/JWTTokenModel.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/models/JWTTokenModel.java
@@ -25,7 +25,7 @@ public class JWTTokenModel {
          jwtPayload= new String(decoder.decode(parts[1]));
          
         // jwtPayload = new JSONObject(payloadJson);
-         String signatureJson = new String(decoder.decode(parts[2]));
+//         String signatureJson = new String(decoder.decode(parts[2]));
          jwtHeader = new JSONObject(headerJson);
          //jwtSign = signatureJson;
         

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/util/CommonUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dataprovider/util/CommonUtil.java
@@ -39,7 +39,7 @@ public class CommonUtil {
 	private static final Logger logger = LoggerFactory.getLogger(CommonUtil.class);
 	private static SecureRandom rand = new SecureRandom();
 
-	private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
+	//private static final char[] HEX_ARRAY = "0123456789ABCDEF".toCharArray();
 
 	public static boolean isExists(List<String> missList, String categoryCode) {
 		if (missList != null) {
@@ -287,10 +287,10 @@ public class CommonUtil {
 	
 	
 	public static void main(String[] args) throws Exception {
-		String regex1 = "^|^0[5-7][0-9]{8}$";
-		String regex2 = "^[a-zA-Zء-ي٠-٩ ]{5,47}$";
-		String regex3 = "(^|^[A-Z]{2}[0-9]{1,6}$)|(^[A-Z]{1}[0-9]{1,7}$)";
-		String regex4 = "^|^(?=.{0,10}$).*";
+		//String regex1 = "^|^0[5-7][0-9]{8}$";
+		//String regex2 = "^[a-zA-Zء-ي٠-٩ ]{5,47}$";
+		//String regex3 = "(^|^[A-Z]{2}[0-9]{1,6}$)|(^[A-Z]{1}[0-9]{1,7}$)";
+		//String regex4 = "^|^(?=.{0,10}$).*";
 
 		String regex5 = "^(1869|18[7-9][0-9]|19[0-9][0-9]|20[0-9][0-9])/([0][1-9]|1[0-2])/([0][1-9]|[1-2][0-9]|3[01])$";
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/report/EmailableReport.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/report/EmailableReport.java
@@ -1,12 +1,12 @@
 package io.mosip.testrig.apirig.report;
 
-import java.io.BufferedReader;
+//import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
+//import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -339,16 +339,16 @@ public class EmailableReport implements IReporter {
 		NumberFormat integerFormat = NumberFormat.getIntegerInstance();
 		LocalDate currentDate = LocalDate.now();
 		String formattedDate =null;
-		String branch = null;
+//		String branch = null;
 		boolean endPointDetailsReported = false;
 		// Format the current date as per your requirement
 		try {
 		
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 	    formattedDate = currentDate.format(formatter);
-		Process process = Runtime.getRuntime().exec("git rev-parse --abbrev-ref HEAD");
-        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-        branch = reader.readLine();
+//		Process process = Runtime.getRuntime().exec("git rev-parse --abbrev-ref HEAD");
+//        BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+//        branch = reader.readLine();
 		}
 		catch (Exception e) {
 			LOG.error("Error writing the date and branch information: " + e.getMessage());
@@ -732,7 +732,7 @@ public class EmailableReport implements IReporter {
 
 				buffer.setLength(0);
 
-				int scenariosPerClass = 0;
+//				int scenariosPerClass = 0;
 				int methodIndex = 0;
 				for (MethodResult methodResult : classResult.getMethodResults()) {
 					List<ITestResult> results = methodResult.getResults();
@@ -769,7 +769,7 @@ public class EmailableReport implements IReporter {
 						scenarioIndex++;
 					}
 
-					scenariosPerClass += resultsCount;
+//					scenariosPerClass += resultsCount;
 					methodIndex++;
 				}
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/OTPListener.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/OTPListener.java
@@ -7,7 +7,7 @@ import java.net.http.WebSocket.Listener;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
+//import java.util.Properties;
 import java.util.concurrent.CompletionStage;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/XmlPrecondtion.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/XmlPrecondtion.java
@@ -37,8 +37,8 @@ public class XmlPrecondtion extends MessagePrecondtion {
 	private static Document xmlDocument;
 	private static final String FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
 	private static final String EXTERNAL_DTD_FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
-	private static final String SAX_EXTERNAL_GENERAL_FEATURE = "http://xml.org/sax/features/external-general-entities";
-	private static final String SAX_EXTERNAL_PARAMETER_FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+//	private static final String SAX_EXTERNAL_GENERAL_FEATURE = "http://xml.org/sax/features/external-general-entities";
+//	private static final String SAX_EXTERNAL_PARAMETER_FEATURE = "http://xml.org/sax/features/external-parameter-entities";
 
 	/**
 	 * The method get node value from xml file

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -52,7 +52,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
+//import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -117,7 +117,7 @@ import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.JsonPrecondtion;
 import io.mosip.testrig.apirig.testrunner.MessagePrecondtion;
 import io.mosip.testrig.apirig.testrunner.OTPListener;
-import io.restassured.RestAssured;
+//import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 
@@ -5882,7 +5882,7 @@ public class AdminTestUtil extends BaseTestCase {
 	public static void getLocationLevelData() {
 
 		Response response = null;
-		JSONObject responseJson = null;
+//		JSONObject responseJson = null;
 		String url = ApplnURI + props.getProperty("fetchLocationHierarchyLevels")
 				+ BaseTestCase.getLanguageList().get(0);
 		String token = kernelAuthLib.getTokenByRole(GlobalConstants.ADMIN);
@@ -5890,7 +5890,7 @@ public class AdminTestUtil extends BaseTestCase {
 		String url2 = "";
 
 		Response responseLocationHierarchy = null;
-		JSONObject responseJsonLocationHierarchy = null;
+//		JSONObject responseJsonLocationHierarchy = null;
 
 		try {
 
@@ -6337,7 +6337,7 @@ public class AdminTestUtil extends BaseTestCase {
 	    org.json.JSONObject responseJson = new org.json.JSONObject(response.asString());
 	    org.json.JSONObject schemaData = (org.json.JSONObject) responseJson.get(GlobalConstants.RESPONSE);
 
-	    Double schemaVersion = ((BigDecimal) schemaData.get(GlobalConstants.ID_VERSION)).doubleValue();
+//	    Double schemaVersion = ((BigDecimal) schemaData.get(GlobalConstants.ID_VERSION)).doubleValue();
 	    idSchemaVersion = ((BigDecimal) schemaData.get(GlobalConstants.ID_VERSION)).doubleValue();
 	    String schemaJsonData = schemaData.getString(GlobalConstants.SCHEMA_JSON);
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AuthTestsUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AuthTestsUtil.java
@@ -13,8 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.attribute.PosixFileAttributes;
-import java.nio.file.attribute.PosixFilePermission;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableEntryException;
@@ -28,16 +26,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
+//import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
-import java.util.function.BiFunction;
+//import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
+//import java.util.stream.Stream;
 
 import javax.ws.rs.core.MediaType;
-import javax.xml.bind.DatatypeConverter;
+//import javax.xml.bind.DatatypeConverter;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
@@ -52,7 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Verify;
 import com.ibm.icu.text.Transliterator;
 
-import io.mosip.authentication.core.spi.indauth.match.MatchType;
+//import io.mosip.authentication.core.spi.indauth.match.MatchType;
 import io.mosip.testrig.apirig.dto.CertificateChainResponseDto;
 import io.mosip.testrig.apirig.dto.OutputValidationDto;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
@@ -71,7 +68,7 @@ public class AuthTestsUtil extends BaseTestCase {
 	private static String testCaseName;
 	private static int testCaseId;
 	private static File testFolder;
-	private static File demoAppBatchFilePath;
+//	private static File demoAppBatchFilePath;
 	public static final String AUTHORIZATHION_COOKIENAME = GlobalConstants.AUTHORIZATION;
 	public static final String authHeaderValue = "Some String";
 	protected static String responseJsonToVerifyDigtalSignature;
@@ -84,50 +81,50 @@ public class AuthTestsUtil extends BaseTestCase {
     }
 
     private ObjectMapper mapper;
-    private static final String PIN = "pin";
+//    private static final String PIN = "pin";
 
-    private static final String BIO = "bio";
+//    private static final String BIO = "bio";
 
-    private static final String DEMO = "demo";
+//    private static final String DEMO = "demo";
 
-    private static final String OTP = "otp";
+//    private static final String OTP = "otp";
     private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
     private static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
 
     private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
-    private static final String TIMESTAMP = "timestamp";
+//    private static final String TIMESTAMP = "timestamp";
 
-    private static final String ID = "id";
+//    private static final String ID = "id";
 
-    private static final String AUTH_TYPE = "authType";
+//    private static final String AUTH_TYPE = "authType";
 
-    private static final String SECONDARY_LANG_CODE = "secondaryLangCode";
+//    private static final String SECONDARY_LANG_CODE = "secondaryLangCode";
 
-    private static final String TXN = "txn";
+//    private static final String TXN = "txn";
 
-    private static final String VER = "ver";
+//    private static final String VER = "ver";
 
-    private static final String ENV = "env";
+//    private static final String ENV = "env";
 
-    private static final String DOMAIN_URI = "domainUri";
-
-    private static final String IDA_API_VERSION = "ida.api.version";
-
-    private static final String MOSIP_ENV = "Staging";
-
-    private static final String MOSIP_DOMAINURI = "mosip.base.url";
+//    private static final String DOMAIN_URI = "domainUri";
+//
+//    private static final String IDA_API_VERSION = "ida.api.version";
+//
+//    private static final String MOSIP_ENV = "Staging";
+//
+//    private static final String MOSIP_DOMAINURI = "mosip.base.url";
     public static final String BIOMETRICS = "biometrics";
-
-    private static final String IDA_AUTH_REQUEST_TEMPLATE = "ida.authRequest.template";
-
-    private static final String DATE_TIME = "dateTime";
-
-    private static final String TRANSACTION_ID = "transactionId";
-
-    private static final String IDENTITY = "Identity";
-
-    private static final String TEMPLATE = "Template";
+//
+//    private static final String IDA_AUTH_REQUEST_TEMPLATE = "ida.authRequest.template";
+//
+//    private static final String DATE_TIME = "dateTime";
+//
+//    private static final String TRANSACTION_ID = "transactionId";
+//
+//    private static final String IDENTITY = "Identity";
+//
+//    private static final String TEMPLATE = "Template";
 
 	/**
 	 * The method will get current test execution folder
@@ -256,69 +253,69 @@ public class AuthTestsUtil extends BaseTestCase {
         return isErrored ? "Upload Failed" : "Upload Success";
     }
     
-    private String digest(byte[] hash) throws NoSuchAlgorithmException {
-        return DatatypeConverter.printHexBinary(hash).toUpperCase();
-    }
-    
+//    private String digest(byte[] hash) throws NoSuchAlgorithmException {
+//        return DatatypeConverter.printHexBinary(hash).toUpperCase();
+//    }
+//    
     public byte[] getCertificateThumbprint(Certificate cert) throws CertificateEncodingException {
         return DigestUtils.sha256(cert.getEncoded());
     }
     
-    private void getAuthTypeMap(String reqAuth, Map<String, Object> reqValues, Map<String, Object> request) {
-        String[] reqAuthArr;
-        if (reqAuth == null) {
-            BiFunction<String, String, Optional<String>> authTypeMapFunction = (key, authType) -> Optional
-                    .ofNullable(request).filter(map -> map.containsKey(key)).map(map -> authType);
-            reqAuthArr = Stream
-                    .of(authTypeMapFunction.apply("demographics", "demo"), authTypeMapFunction.apply(BIOMETRICS, "bio"),
-                            authTypeMapFunction.apply("otp", "otp"), authTypeMapFunction.apply("staticPin", "pin"))
-                    .filter(Optional::isPresent).map(Optional::get).toArray(size -> new String[size]);
-        } else {
-            reqAuth = reqAuth.trim();
-            if (reqAuth.contains(",")) {
-                reqAuthArr = reqAuth.split(",");
-            } else {
-                reqAuthArr = new String[]{reqAuth};
-            }
-        }
-
-        for (String authType : reqAuthArr) {
-            authTypeSelectionMap(reqValues, authType);
-        }
-    }
+//    private void getAuthTypeMap(String reqAuth, Map<String, Object> reqValues, Map<String, Object> request) {
+//        String[] reqAuthArr;
+//        if (reqAuth == null) {
+//            BiFunction<String, String, Optional<String>> authTypeMapFunction = (key, authType) -> Optional
+//                    .ofNullable(request).filter(map -> map.containsKey(key)).map(map -> authType);
+//            reqAuthArr = Stream
+//                    .of(authTypeMapFunction.apply("demographics", "demo"), authTypeMapFunction.apply(BIOMETRICS, "bio"),
+//                            authTypeMapFunction.apply("otp", "otp"), authTypeMapFunction.apply("staticPin", "pin"))
+//                    .filter(Optional::isPresent).map(Optional::get).toArray(size -> new String[size]);
+//        } else {
+//            reqAuth = reqAuth.trim();
+//            if (reqAuth.contains(",")) {
+//                reqAuthArr = reqAuth.split(",");
+//            } else {
+//                reqAuthArr = new String[]{reqAuth};
+//            }
+//        }
+//
+//        for (String authType : reqAuthArr) {
+//            authTypeSelectionMap(reqValues, authType);
+//        }
+//    }
     
-    private void authTypeSelectionMap(Map<String, Object> reqValues, String authType) {
-
-        if (authType.equalsIgnoreCase(MatchType.Category.OTP.getType())) {
-            reqValues.put(OTP, true);
-        } else if (authType.equalsIgnoreCase(MatchType.Category.DEMO.getType())) {
-            reqValues.put(DEMO, true);
-        } else if (authType.equalsIgnoreCase(MatchType.Category.BIO.getType())) {
-            reqValues.put(BIO, true);
-        } else if (authType.equalsIgnoreCase(MatchType.Category.SPIN.getType())) {
-            reqValues.put("pin", true);
-        }
-    }
+//    private void authTypeSelectionMap(Map<String, Object> reqValues, String authType) {
+//
+//        if (authType.equalsIgnoreCase(MatchType.Category.OTP.getType())) {
+//            reqValues.put(OTP, true);
+//        } else if (authType.equalsIgnoreCase(MatchType.Category.DEMO.getType())) {
+//            reqValues.put(DEMO, true);
+//        } else if (authType.equalsIgnoreCase(MatchType.Category.BIO.getType())) {
+//            reqValues.put(BIO, true);
+//        } else if (authType.equalsIgnoreCase(MatchType.Category.SPIN.getType())) {
+//            reqValues.put("pin", true);
+//        }
+//    }
     
-    private void applyRecursively(Object obj, String key, String value) {
-        if (obj instanceof Map) {
-            Map<String, Object> map = (Map<String, Object>) obj;
-            Optional<String> matchingKey = map.keySet().stream().filter(k -> k.equalsIgnoreCase(key)).findFirst();
-            if (matchingKey.isPresent()) {
-                map.put(matchingKey.get(), value);
-            }
-
-            for (Object val : map.values()) {
-                applyRecursively(val, key, value);
-            }
-        } else if (obj instanceof List) {
-            List<?> list = (List<?>) obj;
-            for (Object object : list) {
-                applyRecursively(object, key, value);
-            }
-        }
-    }
-    
+//    private void applyRecursively(Object obj, String key, String value) {
+//        if (obj instanceof Map) {
+//            Map<String, Object> map = (Map<String, Object>) obj;
+//            Optional<String> matchingKey = map.keySet().stream().filter(k -> k.equalsIgnoreCase(key)).findFirst();
+//            if (matchingKey.isPresent()) {
+//                map.put(matchingKey.get(), value);
+//            }
+//
+//            for (Object val : map.values()) {
+//                applyRecursively(val, key, value);
+//            }
+//        } else if (obj instanceof List) {
+//            List<?> list = (List<?>) obj;
+//            for (Object object : list) {
+//                applyRecursively(object, key, value);
+//            }
+//        }
+//    }
+//    
     public String signRequest(
             PartnerTypes partnerType,
             String partnerName,
@@ -1177,29 +1174,29 @@ public class AuthTestsUtil extends BaseTestCase {
 	 * 
 	 * @param path
 	 */
-	private static void changeFilePermissionInLinux(Path path) {
-		try {
-			Set<PosixFilePermission> perms = Files.readAttributes(path, PosixFileAttributes.class).permissions();
-			perms.add(PosixFilePermission.OWNER_WRITE);
-			perms.add(PosixFilePermission.OWNER_READ);
-			perms.add(PosixFilePermission.OWNER_EXECUTE);
-			perms.add(PosixFilePermission.GROUP_WRITE);
-			perms.add(PosixFilePermission.GROUP_READ);
-			perms.add(PosixFilePermission.GROUP_EXECUTE);
-			Files.setPosixFilePermissions(path, perms);
-		} catch (Exception e) {
-			IDASCRIPT_LOGGER.error("Exception in change the file permission:" + e.getMessage());
-		}
-	}
+//	private static void changeFilePermissionInLinux(Path path) {
+//		try {
+//			Set<PosixFilePermission> perms = Files.readAttributes(path, PosixFileAttributes.class).permissions();
+//			perms.add(PosixFilePermission.OWNER_WRITE);
+//			perms.add(PosixFilePermission.OWNER_READ);
+//			perms.add(PosixFilePermission.OWNER_EXECUTE);
+//			perms.add(PosixFilePermission.GROUP_WRITE);
+//			perms.add(PosixFilePermission.GROUP_READ);
+//			perms.add(PosixFilePermission.GROUP_EXECUTE);
+//			Files.setPosixFilePermissions(path, perms);
+//		} catch (Exception e) {
+//			IDASCRIPT_LOGGER.error("Exception in change the file permission:" + e.getMessage());
+//		}
+//	}
 
-	private static File fileDemoAppJarPath;
-
-	/**
-	 * The method use to add partnerID and License key in endpoint url
-	 * 
-	 * @param file
-	 * @return PartnerID and LicenseKey
-	 */
+//	private static File fileDemoAppJarPath;
+//
+//	/**
+//	 * The method use to add partnerID and License key in endpoint url
+//	 * 
+//	 * @param file
+//	 * @return PartnerID and LicenseKey
+//	 */
 	public String getExtendedUrl(File file) {
 		if (file.exists()) {
 			Map<String, String> urlProperty = getPropertyAsMap(file.getAbsolutePath());
@@ -1221,7 +1218,7 @@ public class AuthTestsUtil extends BaseTestCase {
 	 * @return version of demoApp as string
 	 */
 	public static String getDemoAppVersion() {
-		String expression = "//dependency/artifactId[text()='authentication-partnerdemo-service']//following::version";
+//		String expression = "//dependency/artifactId[text()='authentication-partnerdemo-service']//following::version";
 		return RunConfigUtil.getdemoAppVersion();
 	}
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/BioDataUtility.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/BioDataUtility.java
@@ -14,7 +14,7 @@ import org.apache.log4j.Logger;
 import org.json.JSONObject;
 
 import io.mosip.kernel.core.util.CryptoUtil;
-import io.mosip.kernel.core.util.HMACUtils;
+//import io.mosip.kernel.core.util.HMACUtils;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.JsonPrecondtion;
 import io.mosip.testrig.apirig.utils.Encrypt.SplittedEncryptedData;
@@ -49,7 +49,7 @@ public class BioDataUtility extends AdminTestUtil {
 					"request.referenceId");
 		jsonContent = JsonPrecondtion.parseAndReturnJsonContent(jsonContent, aad, "request.aad");
 		jsonContent = JsonPrecondtion.parseAndReturnJsonContent(jsonContent, salt, "request.salt");
-		jsonContent = JsonPrecondtion.parseAndReturnJsonContent(jsonContent,  CryptoUtil.encodeBase64(CryptoUtil.decodeBase64(isoBiovalue)), "request.data");
+//		jsonContent = JsonPrecondtion.parseAndReturnJsonContent(jsonContent,  CryptoUtil.encodeBase64(CryptoUtil.decodeBase64(isoBiovalue)), "request.data");
 		jsonContent = JsonPrecondtion.parseAndReturnJsonContent(jsonContent,
 				AdminTestUtil.generateCurrentUTCTimeStamp(), "request.timeStamp");
 		jsonContent = JsonPrecondtion.parseAndReturnJsonContent(jsonContent,
@@ -83,15 +83,15 @@ public class BioDataUtility extends AdminTestUtil {
 	
 	
 
-	private String getHash(String content) {
-		return HMACUtils.digestAsPlainText(HMACUtils.generateHash(content.getBytes()));
-	}
+//	private String getHash(String content) {
+//		return HMACUtils.digestAsPlainText(HMACUtils.generateHash(content.getBytes()));
+//	}
 	
 	public String constructBiorequest(String input, String bioValueencryptionTemplateJson, boolean isInternal, String testCaseName) throws Exception {
 		String bioValue = null;
 		String  timestamp = null;
 		String transactionId = null;
-		String previousHash = getHash("");
+//		String previousHash = getHash("");
 		byte[] previousBioDataHash = null;
 		byte [] previousDataByteArr =  "".getBytes(StandardCharsets.UTF_8);
 		previousBioDataHash = generateHash(previousDataByteArr);
@@ -130,7 +130,7 @@ public class BioDataUtility extends AdminTestUtil {
 	public String constractBioIdentityRequest(String identityRequest, String bioValueencryptionTemplateJson,
 			String testcaseName, boolean isInternal) throws Exception {
 		int count = AuthTestsUtil.getNumberOfTimeWordPresentInString(identityRequest, "\"data\"");
-		String previousHash = getHash("");
+//		String previousHash = getHash("");
 		byte[] previousBioDataHash = null;
 		byte [] previousDataByteArr =  "".getBytes(StandardCharsets.UTF_8);
 		previousBioDataHash = generateHash(previousDataByteArr);
@@ -196,10 +196,10 @@ public class BioDataUtility extends AdminTestUtil {
 		return identityRequest;
 	}
 	
-	private String getSignedData(String identityDataBlock, String partnerId) {
-
-		return generateSignatureWithRequest(identityDataBlock, partnerId);
-	}
+//	private String getSignedData(String identityDataBlock, String partnerId) {
+//
+//		return generateSignatureWithRequest(identityDataBlock, partnerId);
+//	}
 	
 	private String getSignedBiometrics(String identityDataBlock, String key) {
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/CryptoCore.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/CryptoCore.java
@@ -47,7 +47,7 @@ import io.mosip.kernel.core.crypto.exception.InvalidParamSpecException;
 import io.mosip.kernel.core.crypto.exception.SignatureException;
 import io.mosip.kernel.core.crypto.spi.CryptoCoreSpec;
 import io.mosip.kernel.core.exception.NoSuchAlgorithmException;
-import io.mosip.kernel.core.util.CryptoUtil;
+//import io.mosip.kernel.core.util.CryptoUtil;
 import io.mosip.kernel.core.util.EmptyCheckUtils;
 import io.mosip.kernel.crypto.jce.constant.SecurityExceptionCodeConstant;
 import io.mosip.kernel.crypto.jce.util.CryptoUtils;
@@ -442,7 +442,7 @@ public class CryptoCore implements CryptoCoreSpec<byte[], byte[], SecretKey, Pub
 		JsonWebSignature jws = new JsonWebSignature();
 		try {
 			String[] parts = sign.split(PERIOD_SEPARATOR_REGEX);
-			parts[1] = CryptoUtil.encodeBase64(data);
+//			parts[1] = CryptoUtil.encodeBase64(data);
 			jws.setCompactSerialization(CompactSerializer.serialize(parts));
 			jws.setKey(publicKey);
 			return jws.verifySignature();

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Encrypt.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/Encrypt.java
@@ -51,7 +51,7 @@ public class Encrypt {
 
     public SplittedEncryptedData splitEncryptedData(String data) throws Exception {
         //boolean encryptedDataHasVersion =  env.getProperty("encryptedDataHasVersion", boolean.class, false);
-        boolean encryptedDataHasVersion = false;
+//        boolean encryptedDataHasVersion = false;
         byte[] dataBytes = io.mosip.kernel.core.util.CryptoUtil.decodeURLSafeBase64(data);
         byte[][] splits = splitAtFirstOccurance(dataBytes, keySplitter.getBytes());
         byte[] thumbPrintAndSessionKey = splits[0];

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/EncryptionDecrptionUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/EncryptionDecrptionUtil.java
@@ -24,7 +24,7 @@ import org.apache.log4j.Logger;
 import org.json.JSONObject;
 import org.testng.Reporter;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.mosip.kernel.core.util.HMACUtils2;
 import io.mosip.testrig.apirig.dto.EncryptionResponseDto;
@@ -48,7 +48,7 @@ public class EncryptionDecrptionUtil extends AdminTestUtil{
 	public static String partnerThumbPrint =null;
 	public static String internalThumbPrint =null;
 	public static String idaFirThumbPrint =null;
-	private static ObjectMapper objMapper = new ObjectMapper();
+//	private static ObjectMapper objMapper = new ObjectMapper();
 	private static CryptoUtil cryptoUtil = new CryptoUtil();
 	private static KeyMgrUtil keymgrUtil = new KeyMgrUtil();
 	

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
@@ -1,23 +1,23 @@
 package io.mosip.testrig.apirig.utils;
 
-import java.util.Base64;
+//import java.util.Base64.Encoder;
+import java.util.Date;
+//import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import java.util.Base64.Encoder;
-import java.util.Date;
-
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.DecodedJWT;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.simple.JSONObject;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+//import com.auth0.jwt.interfaces.DecodedJWT;
+
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.OTPListener;
-import io.restassured.RestAssured;
+//import io.restassured.RestAssured;
 import io.restassured.response.Response;
 
 public class KernelAuthentication extends BaseTestCase {
@@ -34,7 +34,7 @@ public class KernelAuthentication extends BaseTestCase {
 
 	private String admin_password = ConfigManager.getUserAdminPassword();
 
-	private String admin_userName = ConfigManager.getUserAdminName();
+//	private String admin_userName = ConfigManager.getUserAdminName();
 
 	private String partner_password = props.get("partner_user_password");
 	private String partner_userName = props.get("partner_userName");

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KeyCloakUserAndAPIKeyGeneration.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KeyCloakUserAndAPIKeyGeneration.java
@@ -204,8 +204,8 @@ public class KeyCloakUserAndAPIKeyGeneration extends AdminTestUtil {
 	public static String createAPIKeyForUpdatedPolicy(){
 		String url = ApplnURI + "/v1/partnermanager/partners/" + partnerId + "/generate/apikey";
 
-		String updateApiKeyUrl = ApplnURI + "/v1/partnermanager/partners/" + partnerId + "/policy/" + updatedPolicyId
-				+ "/apiKey/status";
+//		String updateApiKeyUrl = ApplnURI + "/v1/partnermanager/partners/" + partnerId + "/policy/" + updatedPolicyId
+//				+ "/apiKey/status";
 
 		String token = kernelAuthLib.getTokenByRole("partnernew");
 		

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KeyMgrUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KeyMgrUtil.java
@@ -71,11 +71,11 @@ import org.json.JSONObject;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.mosip.kernel.core.crypto.exception.InvalidKeyException;
+import io.mosip.kernel.core.util.CryptoUtil;
 import io.mosip.testrig.apirig.dto.CertificateChainResponseDto;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.utils.Encrypt.SplittedEncryptedData;
-import io.mosip.kernel.core.crypto.exception.InvalidKeyException;
-import io.mosip.kernel.core.util.CryptoUtil;
 
 
 
@@ -91,7 +91,7 @@ public class KeyMgrUtil {
 	
 	private static final Logger logger = Logger.getLogger(KeyMgrUtil.class);
     /** The Constant DOMAIN_URL. */
-    private static final String DOMAIN_URL = "mosip.base.url";
+//    private static final String DOMAIN_URL = "mosip.base.url";
 
 	/** The Constant CERTIFICATE_TYPE. */
 	private static final String CERTIFICATE_TYPE = "X.509";

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KeyMgrUtility.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KeyMgrUtility.java
@@ -72,7 +72,7 @@ public class KeyMgrUtility {
     @Autowired
     private CryptoCoreUtil cryptoCoreUtil;
 
-    private static final String DOMAIN_URL = "mosip.base.url";
+//    private static final String DOMAIN_URL = "mosip.base.url";
     private static final String CA_P12_FILE_NAME = "-ca.p12";
     private int rpPartnerCertExpiryYears = 5;
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/RunConfigUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/RunConfigUtil.java
@@ -2,7 +2,7 @@ package io.mosip.testrig.apirig.utils;
 
 import java.io.File;
 
-import org.apache.log4j.Logger;
+//import org.apache.log4j.Logger;
 
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 
@@ -14,7 +14,7 @@ import io.mosip.testrig.apirig.testrunner.BaseTestCase;
  */
 public class RunConfigUtil {
 	
-	private static final Logger runConfidUtilLogger = Logger.getLogger(RunConfigUtil.class);
+//	private static final Logger runConfidUtilLogger = Logger.getLogger(RunConfigUtil.class);
 	private static final String idaEnvConfigPath="/ida/TestData/RunConfig/envRunConfig.properties";
 	public static final String resourceFolderName="MosipTemporaryTestResource";
 	

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SkipTestCaseHandler.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SkipTestCaseHandler.java
@@ -6,12 +6,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.log4j.Logger;
+//import org.apache.log4j.Logger;
 
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 
 public class SkipTestCaseHandler {
-	private static final Logger logger = Logger.getLogger(SkipTestCaseHandler.class);
+//	private static final Logger logger = Logger.getLogger(SkipTestCaseHandler.class);
 	private static List<String> testcaseToBeSkippedList = new ArrayList<>();
 
 	// load test cases to be skipped in the execution in the list

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/WebSocketClientUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/WebSocketClientUtil.java
@@ -1,12 +1,24 @@
 package io.mosip.testrig.apirig.utils;
 
-import javax.websocket.*;
-import org.apache.log4j.Logger;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.ClientEndpointConfig;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+
+import org.apache.log4j.Logger;
 
 @ClientEndpoint
 public class WebSocketClientUtil extends Endpoint {


### PR DESCRIPTION
Removed unused local variables in apitest-commons module to improve code cleanliness and avoid compiler warnings.
