### PR TITLE
MOSIP-39719: APITestrig log prints passwords

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/ConfigManager.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/ConfigManager.java
@@ -55,7 +55,7 @@ public class ConfigManager {
 
 		// Log the final propertiesMap to ensure all values have been processed
 		// correctly
-		LOGGER.info("propertiesMap = " + propertiesMap);
+		//LOGGER.info("propertiesMap = " + propertiesMap);
 	}
 	
 	public static void getValueForKeyAddToPropertiesMap(Map<String, Object> propsMap, String key) {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/S3Adapter.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/S3Adapter.java
@@ -45,7 +45,10 @@ public class S3Adapter {
 		logger.info("ConfigManager.getS3UserKey() :: "+ConfigManager.getS3UserKey());
 		logger.info("ConfigManager.getS3Host() :: "+ConfigManager.getS3Host());
 		logger.info("ConfigManager.getS3Region() :: "+ConfigManager.getS3Region());
-		logger.info("ConfigManager.getS3SecretKey() :: "+ConfigManager.getS3SecretKey());
+		logger.info("ConfigManager.getS3SecretKey() :: "
+				+ (ConfigManager.getS3SecretKey() != null && !ConfigManager.getS3SecretKey().isBlank() ? "Masked"
+						: ""));
+
 		try {
 			AWSCredentials awsCredentials = new BasicAWSCredentials(ConfigManager.getS3UserKey(),
 					ConfigManager.getS3SecretKey());


### PR DESCRIPTION
Added a log statement in s3Adapter.java to ensure that sensitive information such as the S3 secret key is not printed in logs. The log now conditionally displays "Masked" if the secret key is present, and an empty string otherwise. This change aligns with security best practices and addresses the issue tracked in task APITestrig - log prints passwords.