### PR TITLE
MOSIP-39108 API - Prefix the run context for every run

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
@@ -246,6 +246,7 @@ public class DBManager {
 									if (line.trim().equals("") || line.trim().startsWith("#"))
 										continue;
 									line = line.replace("${currentModule}", BaseTestCase.currentModule);
+									logger.info("Current query is = " + line);
 									statement.addBatch(line);
 								}
 							} catch (IOException e) {
@@ -285,7 +286,7 @@ public class DBManager {
 			session = factory.getCurrentSession();
 			session.beginTransaction();
 		} catch (HibernateException | NullPointerException e) {
-			logger.error("Error while getting the db connection for ::" + dburl);
+			logger.error("Error while getting the db connection for ::" + dburl, e);
 		}
 		return session;
 	}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
@@ -22,6 +22,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.jdbc.Work;
 import org.testng.Assert;
 
+import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.utils.AdminTestException;
 import io.mosip.testrig.apirig.utils.ConfigManager;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
@@ -244,6 +245,7 @@ public class DBManager {
 								while ((line = bufferedReader.readLine()) != null) {
 									if (line.trim().equals("") || line.trim().startsWith("#"))
 										continue;
+									line = line.replace("${currentModule}", BaseTestCase.currentModule);
 									statement.addBatch(line);
 								}
 							} catch (IOException e) {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dbaccess/DBManager.java
@@ -246,7 +246,6 @@ public class DBManager {
 									if (line.trim().equals("") || line.trim().startsWith("#"))
 										continue;
 									line = line.replace("${currentModule}", BaseTestCase.currentModule);
-									logger.info("Current query is = " + line);
 									statement.addBatch(line);
 								}
 							} catch (IOException e) {
@@ -286,7 +285,7 @@ public class DBManager {
 			session = factory.getCurrentSession();
 			session.beginTransaction();
 		} catch (HibernateException | NullPointerException e) {
-			logger.error("Error while getting the db connection for ::" + dburl, e);
+			logger.error("Error while getting the db connection for ::" + dburl);
 		}
 		return session;
 	}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/report/EmailableReport.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/report/EmailableReport.java
@@ -161,6 +161,8 @@ public class EmailableReport implements IReporter {
 		}
 
 		String oldString = System.getProperty(GlobalConstants.EMAILABLEREPORT2NAME);
+		// Remove unwanted random suffix (e.g., -5e9, -2b9, -abc123) before the module name
+		oldString = oldString.replaceAll("-[a-z0-9]{3,}(?=_)", "");
 		String temp = "";
 		String reportContext = skipPassed == true ? "error-" : "full-";
 		
@@ -876,6 +878,8 @@ public class EmailableReport implements IReporter {
 		int parameterCount = (parameters == null ? 0 : parameters.length);
 		
 		String testCaseName = result.getMethod().getMethodName();
+		// Get the class name
+		String className = result.getMethod().getTestClass().getRealClass().getSimpleName();
 
 		String uniqueIdentifier = (parameterCount > 0 && parameters[0] instanceof TestCaseDTO)
 				? (((TestCaseDTO) parameters[0]).getUniqueIdentifier() != null
@@ -912,6 +916,14 @@ public class EmailableReport implements IReporter {
 		writer.print("<td>");
 		writer.print(Utils.escapeHtml(dependencies.toString()));
 		writer.print("</td>");
+		
+		// Add ClassName
+		writer.print("<tr class=\"param\">");
+		writer.print("<th>Class Name</th>");
+		writer.print("</tr><tr class=\"param stripe\">");
+		writer.print("<td>");
+		writer.print(Utils.escapeHtml(className));
+		writer.print("</td></tr>");
 		
 		writer.print(GlobalConstants.TR);
 		

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/report/EmailableReport.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/report/EmailableReport.java
@@ -407,10 +407,13 @@ public class EmailableReport implements IReporter {
 				writer.print("</pre></td>");
 				writer.print(GlobalConstants.TRTR);
 				
-				writer.print("<tr><th colspan=\"9\"><span class=\"not-bold\"><pre style=\"white-space:pre-wrap; word-wrap:break-word;\">");
-				writer.print(Utils.escapeHtml(GlobalMethods.getTestCaseVariableMapping()));
-				writer.print("</pre></span>");
-				writer.print(GlobalConstants.TRTR);
+				/*
+				 * writer.
+				 * print("<tr><th colspan=\"9\"><span class=\"not-bold\"><pre style=\"white-space:pre-wrap; word-wrap:break-word;\">"
+				 * );
+				 * writer.print(Utils.escapeHtml(GlobalMethods.getTestCaseVariableMapping()));
+				 * writer.print("</pre></span>"); writer.print(GlobalConstants.TRTR);
+				 */
 				
 				if (GlobalMethods.getServerErrors().equals("No server errors")) {
 					writer.print("<tr><th colspan=\"9\"><span class=\"not-bold\"><pre>");

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
@@ -188,6 +188,8 @@ public class BaseTestCase {
 	private static String runTypeS = "";
 	protected static String jarURLS = "";
 	
+	public static String runContext = GlobalMethods.getRunContext();
+	
 	public static void setLogLevel() {
 		if (ConfigManager.IsDebugEnabled())
 			logger.setLevel(Level.ALL);

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
@@ -162,8 +162,10 @@ public class BaseTestCase {
 	public String genPolicyNameNonAuth = "policyNameForEsignet" + generateRandomNumberString(4);
 	public String genMispPolicyName = "policyNameForMispEsi" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
-	public static String genPartnerName = "partnernameforautomationesi-" + generateRandomNumberString(6);
-	public static String genPartnerNameNonAuth = "partnernameforesignet-" + generateRandomNumberString(6);
+	//public static String genPartnerName = "partnernameforautomationesi-" + generateRandomNumberString(6);
+	public static String genPartnerName = null;
+	//public static String genPartnerNameNonAuth = "partnernameforesignet-" + generateRandomNumberString(6);
+	public static String genPartnerNameNonAuth = BaseTestCase.currentModule + "-partnernameforesignet";
 	public String genPartnerNameForDsl = "partnernameforautomationdsl-" + generateRandomNumberString(6);
 	public static String genMispPartnerName = "esignet_" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
@@ -214,6 +216,10 @@ public class BaseTestCase {
 	 * partnerId = "Tech-1245"; static String emailId = "mosip_1" + timeStamp +
 	 * "@gmail.com"; static String role = PartnerRegistration.partnerType;
 	 */
+	
+	public static void initializePMSDetails() {
+		genPartnerName = BaseTestCase.currentModule + "-partnernameforautomationesi";
+	}
 	
 	public static String getGlobalResourcePath() {
 		if (cachedPath != null) {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -172,7 +172,7 @@ public class AdminTestUtil extends BaseTestCase {
 	protected static String preregHbsForCreate = null;
 	protected static String preregHbsForUpdate = null;
 	protected static String timeStamp = String.valueOf(Calendar.getInstance().getTimeInMillis());
-	protected static String policyGroup = "mosip auth policy group " + timeStamp;
+	protected static String policyGroup = "mosip auth policy group " + BaseTestCase.runContext + timeStamp;
 	protected static String mispPolicyGroup = "mosip misp policy group " + timeStamp;
 	protected static String policyGroupForUpdate = "mosip auth policy group update " + timeStamp;
 	protected static String policyGroup2 = "mosip auth policy group2 " + timeStamp;
@@ -237,10 +237,14 @@ public class AdminTestUtil extends BaseTestCase {
 	public static boolean isCaptchaEnabled() {
 		String temp = getValueFromEsignetActuator(GlobalConstants.CLASS_PATH_APPLICATION_PROPERTIES,
 				GlobalConstants.MOSIP_ESIGNET_CAPTCHA_REQUIRED);
-		if (temp.isEmpty()) {
-			return false;
-		}
-		return true;
+		 // Throw NPE if temp is null
+	    if (temp == null) {
+	        throw new NullPointerException("Captcha property value is null");
+	    } else if(temp.isEmpty()) {
+	    	return false;
+	    } else {
+	    	return true;
+	    }
 	}
 
 	/**
@@ -274,10 +278,10 @@ public class AdminTestUtil extends BaseTestCase {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = uriKeyWordHandelerUri(url, testCaseName);
-		if (BaseTestCase.currentModule.equals(GlobalConstants.PREREG) || BaseTestCase.currentModule.equals("auth")
-				|| BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.DSL)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.PREREG) || BaseTestCase.currentModule.contains("auth")
+				|| BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.DSL)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
 
@@ -470,7 +474,7 @@ public class AdminTestUtil extends BaseTestCase {
 		}
 
 		inputJson = request.toString();
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)
 				|| BaseTestCase.currentModule.equals(GlobalConstants.DSL)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
@@ -569,11 +573,11 @@ public class AdminTestUtil extends BaseTestCase {
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 
 		url = inputJsonKeyWordHandeler(url, testCaseName);
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.equals("auth")
-				|| BaseTestCase.currentModule.equals(GlobalConstants.ESIGNET)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.DSL)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.contains("auth")
+				|| BaseTestCase.currentModule.contains(GlobalConstants.ESIGNET)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.DSL)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
 
@@ -644,9 +648,9 @@ public class AdminTestUtil extends BaseTestCase {
 		}
 
 		inputJson = request.toString();
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.equals("auth")
-				|| BaseTestCase.currentModule.equals(GlobalConstants.ESIGNET)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.contains("auth")
+				|| BaseTestCase.currentModule.contains(GlobalConstants.ESIGNET)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
 
@@ -764,7 +768,7 @@ public class AdminTestUtil extends BaseTestCase {
 		headers.put("PARTNER-ID", partnerId);
 		headers.put(cookieName, "Bearer " + token);
 		inputJson = req.toString();
-		if (BaseTestCase.currentModule.equals(GlobalConstants.ESIGNET)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.ESIGNET)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
 
@@ -1048,10 +1052,10 @@ public class AdminTestUtil extends BaseTestCase {
 			String testCaseName, boolean bothAccessAndIdToken) throws SecurityXSSException {
 		Response response = null;
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.equals("auth")
-				|| BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.DSL)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.contains("auth")
+				|| BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.DSL)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
 
@@ -1095,7 +1099,7 @@ public class AdminTestUtil extends BaseTestCase {
 		if (url.contains("ID:"))
 			url = inputJsonKeyWordHandeler(url, testCaseName);
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
-		if (BaseTestCase.currentModule.equals("auth") || BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)) {
+		if (BaseTestCase.currentModule.contains("auth") || BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
 		token = kernelAuthLib.getTokenByRole(role);
@@ -1192,12 +1196,12 @@ public class AdminTestUtil extends BaseTestCase {
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 
 		url = inputJsonKeyWordHandeler(url, testCaseName);
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.equals("auth")
-				|| BaseTestCase.currentModule.equals(GlobalConstants.ESIGNET)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.PREREG)
-				|| BaseTestCase.currentModule.equals(GlobalConstants.DSL)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MIMOTO) || BaseTestCase.currentModule.contains("auth")
+				|| BaseTestCase.currentModule.contains(GlobalConstants.ESIGNET)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.PREREG)
+				|| BaseTestCase.currentModule.contains(GlobalConstants.DSL)) {
 			inputJson = smtpOtpHandler(inputJson, testCaseName);
 		}
 		if (bothAccessAndIdToken) {
@@ -2769,7 +2773,7 @@ public class AdminTestUtil extends BaseTestCase {
 			String testCaseName, boolean bothAccessAndIdToken) {
 		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
 		url = inputJsonKeyWordHandeler(url, testCaseName);
-		if (BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)) {
 			jsonInput = smtpOtpHandler(inputJson, testCaseName);
 		}
 		byte[] pdf = null;
@@ -3270,7 +3274,7 @@ public class AdminTestUtil extends BaseTestCase {
 		int indexof = testCaseName.indexOf("_");
 		String autogenIdKeyName = testCaseName.substring(indexof + 1);
 		if (fieldName.equals("VID")
-				&& (BaseTestCase.currentModule.equals("auth") || BaseTestCase.currentModule.equals("esignet"))) {
+				&& (BaseTestCase.currentModule.contains("auth") || BaseTestCase.currentModule.contains("esignet"))) {
 			autogenIdKeyName = autogenIdKeyName + "_" + fieldName.toLowerCase();
 		} else {
 			autogenIdKeyName = autogenIdKeyName + "_" + fieldName;
@@ -5912,7 +5916,11 @@ public class AdminTestUtil extends BaseTestCase {
 
 		try {
 			Response response = RestClient.getRequest(url, MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON);
+			// Get actual response body
+			String responseBody = response.getBody().asString();
+			System.out.println("Actuator response body: " + responseBody);
 			JSONObject responseJson = new JSONObject(response.getBody().asString());
+			
 
 			// If the key exists in the response, return the associated JSONArray
 			if (responseJson.has(key)) {
@@ -6113,7 +6121,7 @@ public class AdminTestUtil extends BaseTestCase {
 		JSONObject request = new JSONObject(inputJson);
 		String emailId = null;
 		String otp = null;
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MIMOTO) || testCaseName.startsWith("auth_OTP_Auth")
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MIMOTO) || testCaseName.startsWith("auth_OTP_Auth")
 				|| testCaseName.startsWith("auth_EkycOtp") || testCaseName.startsWith("auth_MultiFactorAuth")
 				|| testCaseName.startsWith("Ida_EkycOtp") || testCaseName.startsWith("Ida_OTP_Auth")) {
 			if (request.has("otp")) {
@@ -6134,7 +6142,7 @@ public class AdminTestUtil extends BaseTestCase {
 				}
 			}
 		}
-		if (BaseTestCase.currentModule.equals(GlobalConstants.PREREG)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.PREREG)) {
 			if (request.has(GlobalConstants.REQUEST)) {
 				if (request.getJSONObject(GlobalConstants.REQUEST).has("otp")) {
 					emailId = request.getJSONObject(GlobalConstants.REQUEST).getString("userId");
@@ -6152,7 +6160,7 @@ public class AdminTestUtil extends BaseTestCase {
 				}
 			}
 		}
-		if (BaseTestCase.currentModule.equals("auth")) {
+		if (BaseTestCase.currentModule.contains("auth")) {
 			if (testCaseName.startsWith("auth_GenerateVID") || testCaseName.startsWith("auth_AuthLock")
 					|| testCaseName.startsWith("auth_AuthUnLock") || testCaseName.startsWith("auth_RevokeVID")) {
 				if (request.has(GlobalConstants.REQUEST)) {
@@ -6176,7 +6184,7 @@ public class AdminTestUtil extends BaseTestCase {
 				}
 			}
 		}
-		if (BaseTestCase.currentModule.equals(GlobalConstants.MASTERDATA)
+		if (BaseTestCase.currentModule.contains(GlobalConstants.MASTERDATA)
 				|| BaseTestCase.currentModule.equals(GlobalConstants.DSL)) {
 			if (testCaseName.startsWith("Resident_GenerateVID")
 					|| testCaseName.startsWith("ESignet_AuthenticateUserIDP")
@@ -6241,7 +6249,7 @@ public class AdminTestUtil extends BaseTestCase {
 				}
 			}
 		}
-		if (BaseTestCase.currentModule.equals(GlobalConstants.ESIGNET)
+		if (BaseTestCase.currentModule.contains(GlobalConstants.ESIGNET)
 				|| testCaseName.startsWith("Mimoto_WalletBinding")
 				|| testCaseName.startsWith("Mimoto_ESignet_AuthenticateUser")) {
 			if (request.has(GlobalConstants.REQUEST)) {
@@ -6296,7 +6304,7 @@ public class AdminTestUtil extends BaseTestCase {
 				}
 			}
 		}
-		if (BaseTestCase.currentModule.equals(GlobalConstants.RESIDENT)) {
+		if (BaseTestCase.currentModule.contains(GlobalConstants.RESIDENT)) {
 			if (request.has(GlobalConstants.REQUEST)) {
 				if (request.getJSONObject(GlobalConstants.REQUEST).has("otp")) {
 					if (request.getJSONObject(GlobalConstants.REQUEST).getString("otp")

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
@@ -74,7 +74,8 @@ public class GlobalMethods {
 	}
 	
 	public static String getRunContext() {
-		// Generate a UUID, remove dashes, convert to lowercase, and take first 6 characters
+		// Generate a UUID, remove dashes,convert to lowercase, and take first 6
+		// characters
 		runContext = UUID.randomUUID().toString().replaceAll("-", "").toLowerCase().substring(0, 3) + "_";
 		logger.info("RUN_CONTEXT set to: " + runContext);
 		return runContext;

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -35,6 +36,7 @@ public class GlobalMethods {
 	private static Pattern pattern_1 = Pattern.compile(regex_1);
 	private static Pattern pattern_2 = Pattern.compile(regex_2);
 	
+	public static String runContext = null;	
 	
 	public static boolean isXSSProtectionCheckEnabled() {
 		return ConfigManager.getproperty("xssProtectionCheck").equalsIgnoreCase("yes") ? true : false;
@@ -69,6 +71,13 @@ public class GlobalMethods {
 		// Recompile the regex patterns based on the new regex strings
 		pattern_1 = Pattern.compile(regex_1);
 		pattern_2 = Pattern.compile(regex_2);
+	}
+	
+	public static String getRunContext() {
+		// Generate a UUID, remove dashes, convert to lowercase, and take first 6 characters
+		runContext = UUID.randomUUID().toString().replaceAll("-", "").toLowerCase().substring(0, 3) + "_";
+		logger.info("RUN_CONTEXT set to: " + runContext);
+		return runContext;
 	}
 
 	public static void main(String[] arg) {


### PR DESCRIPTION
- Generated a random 6-character prefix using UUID.
- Set BaseTestCase.currentModule and certsForModule with the prefix.
- Replaced ${currentModule} dynamically in input templates and DB cleanup queries.
- Ensured only relevant test data is created and cleaned per run.