### PR TITLE
Changed the apitest-commons version in develop branch.

### DIFF
--- a/apitest-commons/pom.xml
+++ b/apitest-commons/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-commons</name>
 	<description>Parent project of MOSIP functional tests</description>
 	<url>https://github.com/mosip/mosip-functional-tests</url>
-	<version>1.2.1-SNAPSHOT</version>
+	<version>1.3.4-SNAPSHOT</version>
 
 	<licenses>
 		<license>

--- a/apitest-commons/pom.xml
+++ b/apitest-commons/pom.xml
@@ -67,7 +67,7 @@
 		<maven.model.version>3.3.9</maven.model.version>
 		<testng.version>7.11.0</testng.version>
 		<zt.zip.version>1.13</zt.zip.version>
-		<fileName>apitest-commons-1.2.1-SNAPSHOT-jar-with-dependencies</fileName>
+		<fileName>apitest-commons-1.3.4-SNAPSHOT-jar-with-dependencies</fileName>
 	</properties>
 	
 	<dependencies>

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
@@ -162,10 +162,10 @@ public class BaseTestCase {
 	public String genPolicyNameNonAuth = "policyNameForEsignet" + generateRandomNumberString(4);
 	public String genMispPolicyName = "policyNameForMispEsi" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
-	//public static String genPartnerName = "partnernameforautomationesi-" + generateRandomNumberString(6);
-	public static String genPartnerName = null;
-	//public static String genPartnerNameNonAuth = "partnernameforesignet-" + generateRandomNumberString(6);
-	public static String genPartnerNameNonAuth = BaseTestCase.currentModule + "-partnernameforesignet";
+	public static String genPartnerName = "partnernameforautomationesi-" + generateRandomNumberString(6);
+	//public static String genPartnerName = null;
+	public static String genPartnerNameNonAuth = "partnernameforesignet-" + generateRandomNumberString(6);
+	//public static String genPartnerNameNonAuth = BaseTestCase.currentModule + "-partnernameforesignet";
 	public String genPartnerNameForDsl = "partnernameforautomationdsl-" + generateRandomNumberString(6);
 	public static String genMispPartnerName = "esignet_" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
@@ -217,10 +217,10 @@ public class BaseTestCase {
 	 * "@gmail.com"; static String role = PartnerRegistration.partnerType;
 	 */
 	
-	public static void initializePMSDetails() {
-		genPartnerName = BaseTestCase.currentModule + "-partnernameforautomationesi";
-	}
-	
+	/*
+	 * public static void initializePMSDetails() { genPartnerName =
+	 * BaseTestCase.currentModule + "-partnernameforautomationesi"; }
+	 */
 	public static String getGlobalResourcePath() {
 		if (cachedPath != null) {
 			return cachedPath;


### PR DESCRIPTION
Updated project version from 1.2.1-SNAPSHOT to 1.3.4-SNAPSHOT in pom.xml.
Refactored BaseTestCase.java:
- Activated genPartnerName with random number generation (was previously commented/null).
- Changed genPartnerNameNonAuth to use a fixed "partnernameforesignet-" instead of being dynamically built from BaseTestCase.currentModule.
- Commented out the old unused/null declarations.