### PR TITLE
Changes required for certify testcases related to Ledger API

### DIFF
--- a/apitest-commons/pom.xml
+++ b/apitest-commons/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-commons</name>
 	<description>Parent project of MOSIP functional tests</description>
 	<url>https://github.com/mosip/mosip-functional-tests</url>
-	<version>1.3.4-SNAPSHOT</version>
+	<version>1.3.5-SNAPSHOT</version>
 
 	<licenses>
 		<license>
@@ -67,7 +67,7 @@
 		<maven.model.version>3.3.9</maven.model.version>
 		<testng.version>7.11.0</testng.version>
 		<zt.zip.version>1.13</zt.zip.version>
-		<fileName>apitest-commons-1.3.4-SNAPSHOT-jar-with-dependencies</fileName>
+		<fileName>apitest-commons-1.3.5-SNAPSHOT-jar-with-dependencies</fileName>
 	</properties>
 	
 	<dependencies>

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/JsonPrecondtion.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/JsonPrecondtion.java
@@ -357,10 +357,13 @@ public class JsonPrecondtion extends MessagePrecondtion{
 	 * @return String
 	 */
 	public static String toPrettyFormat(String jsonString) {
-		Gson gson = new GsonBuilder().setPrettyPrinting().create();
-		JsonParser jp = new JsonParser();
-		JsonElement je = jp.parse(jsonString);
-		return gson.toJson(je);
+	    Gson gson = new GsonBuilder()
+	            .setPrettyPrinting()
+	            .serializeNulls()
+	            .create();
+	    JsonParser jp = new JsonParser();
+	    JsonElement je = jp.parse(jsonString);
+	    return gson.toJson(je);
 	}
 	
 	/**


### PR DESCRIPTION
Changes are required in the JsonPrecondition Java class, as ApiTestrig is skipping attributes in the request/response JSON when their values are null.