### PR TITLE
MOSIP-43105: Updated the POM file and Readme file apitest commons 1.3.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use this repository, ensure you have:
     <dependency>
       <groupId>io.mosip.testrig.apirig.apitest.commons</groupId>
       <artifactId>apitest-commons</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
 
 ---

--- a/apitest-commons/README.md
+++ b/apitest-commons/README.md
@@ -84,7 +84,7 @@ Ensure the following software is installed on the machine from where the automat
     <dependency>
       <groupId>io.mosip.testrig.apitest.commons</groupId>
       <artifactId>apitest-commons</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
 
 ---

--- a/apitest-commons/pom.xml
+++ b/apitest-commons/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-commons</name>
 	<description>Parent project of MOSIP functional tests</description>
 	<url>https://github.com/mosip/mosip-functional-tests</url>
-	<version>1.3.3</version>
+	<version>1.3.4-SNAPSHOT</version>
 
 	<licenses>
 		<license>
@@ -67,7 +67,7 @@
 		<maven.model.version>3.3.9</maven.model.version>
 		<testng.version>7.11.0</testng.version>
 		<zt.zip.version>1.13</zt.zip.version>
-		<fileName>apitest-commons-1.3.3-jar-with-dependencies</fileName>
+		<fileName>apitest-commons-1.3.4-SNAPSHOT-jar-with-dependencies</fileName>
 	</properties>
 	
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>io.mosip.testrig</groupId>
 	<artifactId>mosip-functional-test</artifactId>
-	<version>1.3.3</version>
+	<version>1.3.4-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>mosip-function-test</name>
 	<description>Parent project of MOSIP Functional test</description>


### PR DESCRIPTION
MOSIP-43105: Updated the POM file and Readme file apitest commons 1.3.4 release

- This release is for helm chart and deployment scripts update. No code change from automation