### PR TITLE
MOSIP-44098 - Move common JWT decode utilities from EsignetUtil to AdminTestUtil

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -96,6 +96,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jknack.handlebars.Context;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
@@ -7740,5 +7741,86 @@ public class AdminTestUtil extends BaseTestCase {
 	    }
 	    return null;
 	}
+
+	protected Response patchWithPathParamsBodyHeaderWithBearerToken(String url, String jsonInput, String cookieName, String role,
+			String testCaseName, String pathParams) throws SecurityXSSException {
+		Response response = null;
+		String inputJson = inputJsonKeyWordHandeler(jsonInput, testCaseName);
+		JSONObject req = new JSONObject(inputJson);
+		HashMap<String, String> pathParamsMap = new HashMap<>();
+		String[] params = pathParams.split(",");
+		for (String param : params) {
+			if (req.has(param)) {
+				pathParamsMap.put(param, req.get(param).toString());
+				req.remove(param);
+			} else
+				logger.error(GlobalConstants.ERROR_STRING_2 + param + GlobalConstants.IN_STRING + inputJson);
+		}
+
+		token = kernelAuthLib.getAuthTokenByRole(role);
+
+		logger.info(GlobalConstants.PUT_REQ_STRING + url);
+		GlobalMethods.reportRequest(null, req.toString(), url);
+		try {
+			response = RestClient.patchWithPathParamsBodyHeaderWithBearerToken(url, pathParamsMap, req.toString(),
+					MediaType.APPLICATION_JSON, MediaType.APPLICATION_JSON, cookieName, token);
+			// check if X-XSS-Protection is enabled or not
+			GlobalMethods.checkXSSProtectionHeader(response, url);
+			GlobalMethods.reportResponse(response.getHeaders().asList().toString(), url, response);
+			return response;
+		} catch (SecurityXSSException se) {
+			String responseHeadersString = (response == null) ? "No response"
+					: response.getHeaders().asList().toString();
+			String errorMessageString = "XSS check failed for URL: " + url + "\nHeaders: " + responseHeadersString
+					+ "\nError: " + se.getMessage();
+			logger.error(errorMessageString, se);
+			throw se;
+		} catch (Exception e) {
+			logger.error(GlobalConstants.EXCEPTION_STRING_2 + e);
+			return response;
+		}
+	}
 	
+	public static String decodeBase64Url(String value) {
+		try {
+			byte[] decodedBytes = Base64.getUrlDecoder().decode(value);
+			return new String(decodedBytes, StandardCharsets.UTF_8);
+		} catch (Exception e) {
+			logger.error("Error decoding Base64Url: " + value, e);
+			return null;
+		}
+	}
+
+	public static String decodeAndCombineJwt(String jwtString) {
+		try {
+
+			if (jwtString == null || jwtString.isEmpty()) {
+				logger.error("JWT string is empty");
+				return null;
+			}
+
+			DecodedJWT jwt = JWT.decode(jwtString);
+
+			String headerJson = decodeBase64Url(jwt.getHeader());
+			String payloadJson = decodeBase64Url(jwt.getPayload());
+
+			if (headerJson == null || payloadJson == null) {
+				logger.error("Failed to decode JWT parts");
+				return null;
+			}
+
+			ObjectMapper mapper = new ObjectMapper();
+			ObjectNode combinedJson = mapper.createObjectNode();
+
+			combinedJson.set("header", mapper.readTree(headerJson));
+			combinedJson.set("payload", mapper.readTree(payloadJson));
+
+			return mapper.writeValueAsString(combinedJson);
+
+		} catch (Exception e) {
+			logger.error("Error decoding JWT: " + e.getMessage(), e);
+			return null;
+		}
+	}
+
 }

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
@@ -258,22 +258,20 @@ public class KernelAuthentication extends BaseTestCase {
 		
 	}
 
-	private static Response sendPostRequest(String url, Map<String, String> params) {
-		try {
-			return RestClient.postRequestWithFormDataBody(url, params);
-		} catch (Exception e) {
-			logger.error("Error sending POST request to URL: " + url, e);
-			return null;
-		}
-	}
-	
 	public static String getAuthTokenFromKeyCloak(String clientId, String clientSecret) {
 		Map<String, String> params = new HashMap<>();
 		params.put(CLIENT_ID, clientId);
 		params.put(CLIENT_SECRET, clientSecret);
 		params.put(GRANT_TYPE_KEY, GRANT_TYPE);
 
-		Response response = sendPostRequest(TOKEN_URL, params);
+		Response response = null;
+
+		try {
+			response = RestClient.postRequestWithFormDataBody(TOKEN_URL, params);
+		} catch (Exception e) {
+			logger.error("Error sending POST request to Keycloak token URL: " + TOKEN_URL, e);
+			return "";
+		}
 
 		if (response == null) {
 			logger.error("Keycloak token request returned null response");

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
@@ -84,8 +84,8 @@ public class KernelAuthentication extends BaseTestCase {
 	private static final String GRANT_TYPE_KEY = "grant_type";
 	private static final String ACCESS_TOKEN = "access_token";
 	
-    private static String partnerCookie = null;
-    private static String mobileAuthCookie = null;
+    private static String partnerKeycloakToken = null;
+    private static String mobileAuthKeycloakCookie = null;
 	
 	public static void setLogLevel() {
 		if (ConfigManager.IsDebugEnabled())
@@ -267,22 +267,28 @@ public class KernelAuthentication extends BaseTestCase {
 		}
 	}
 	
-    public static String getAuthTokenFromKeyCloak(String clientId, String clientSecret) {
-        Map<String, String> params = new HashMap<>();
-        params.put(CLIENT_ID, clientId);
-        params.put(CLIENT_SECRET, clientSecret);
-        params.put(GRANT_TYPE_KEY, GRANT_TYPE);
+	public static String getAuthTokenFromKeyCloak(String clientId, String clientSecret) {
+		Map<String, String> params = new HashMap<>();
+		params.put(CLIENT_ID, clientId);
+		params.put(CLIENT_SECRET, clientSecret);
+		params.put(GRANT_TYPE_KEY, GRANT_TYPE);
 
-        Response response = sendPostRequest(TOKEN_URL, params);
+		Response response = sendPostRequest(TOKEN_URL, params);
 
-        if (response == null) {
-            return "";
-        }
-        logger.info(response.getBody().asString());
+		if (response == null) {
+			logger.error("Keycloak token request returned null response");
+			return "";
+		}
+		int statusCode = response.getStatusCode();
+		if (statusCode < 200 || statusCode >= 300) {
+			logger.error("Keycloak token request failed with status code: " + statusCode);
+			return "";
+		}
+		logger.info("Keycloak token request successful");
 
-        org.json.JSONObject responseJson = new org.json.JSONObject(response.getBody().asString());
-        return responseJson.optString(ACCESS_TOKEN, "");
-    }
+		org.json.JSONObject responseJson = new org.json.JSONObject(response.getBody().asString());
+		return responseJson.optString(ACCESS_TOKEN, "");
+	}
 	
 	public static String getAuthTokenByRole(String role) {
 		if (role == null)
@@ -291,17 +297,17 @@ public class KernelAuthentication extends BaseTestCase {
 		String roleLowerCase = role.toLowerCase();
 		switch (roleLowerCase) {
 		case "partner":
-			if (!AdminTestUtil.isValidToken(partnerCookie)) {
-				partnerCookie = getAuthTokenFromKeyCloak(ConfigManager.getPmsClientId(),
+			if (!AdminTestUtil.isValidToken(partnerKeycloakToken)) {
+				partnerKeycloakToken = getAuthTokenFromKeyCloak(ConfigManager.getPmsClientId(),
 						ConfigManager.getPmsClientSecret());
 			}
-			return partnerCookie;
+			return partnerKeycloakToken;
 		case "mobileauth":
-			if (!AdminTestUtil.isValidToken(mobileAuthCookie)) {
-				mobileAuthCookie = getAuthTokenFromKeyCloak(ConfigManager.getMPartnerMobileClientId(),
+			if (!AdminTestUtil.isValidToken(mobileAuthKeycloakCookie)) {
+				mobileAuthKeycloakCookie = getAuthTokenFromKeyCloak(ConfigManager.getMPartnerMobileClientId(),
 						ConfigManager.getMPartnerMobileClientSecret());
 			}
-			return mobileAuthCookie;
+			return mobileAuthKeycloakCookie;
 		default:
 			return "";
 		}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/KernelAuthentication.java
@@ -76,6 +76,17 @@ public class KernelAuthentication extends BaseTestCase {
 	protected static final String ESIGNETUINCOOKIESRESPONSE = "ESignetUINCookiesResponse";
 	protected static final String ESIGNETVIDCOOKIESRESPONSE = "ESignetVIDCookiesResponse";
 	
+	private static final String TOKEN_URL = ConfigManager.getproperty("keycloak-external-url")
+			+ ConfigManager.getproperty("keycloakAuthTokenEndPoint");
+	private static final String GRANT_TYPE = "client_credentials";
+	private static final String CLIENT_ID = "client_id";
+	private static final String CLIENT_SECRET = "client_secret";
+	private static final String GRANT_TYPE_KEY = "grant_type";
+	private static final String ACCESS_TOKEN = "access_token";
+	
+    private static String partnerCookie = null;
+    private static String mobileAuthCookie = null;
+	
 	public static void setLogLevel() {
 		if (ConfigManager.IsDebugEnabled())
 			logger.setLevel(Level.ALL);
@@ -245,6 +256,55 @@ public class KernelAuthentication extends BaseTestCase {
 			return adminCookie;
 		}
 		
+	}
+
+	private static Response sendPostRequest(String url, Map<String, String> params) {
+		try {
+			return RestClient.postRequestWithFormDataBody(url, params);
+		} catch (Exception e) {
+			logger.error("Error sending POST request to URL: " + url, e);
+			return null;
+		}
+	}
+	
+    public static String getAuthTokenFromKeyCloak(String clientId, String clientSecret) {
+        Map<String, String> params = new HashMap<>();
+        params.put(CLIENT_ID, clientId);
+        params.put(CLIENT_SECRET, clientSecret);
+        params.put(GRANT_TYPE_KEY, GRANT_TYPE);
+
+        Response response = sendPostRequest(TOKEN_URL, params);
+
+        if (response == null) {
+            return "";
+        }
+        logger.info(response.getBody().asString());
+
+        org.json.JSONObject responseJson = new org.json.JSONObject(response.getBody().asString());
+        return responseJson.optString(ACCESS_TOKEN, "");
+    }
+	
+	public static String getAuthTokenByRole(String role) {
+		if (role == null)
+			return "";
+
+		String roleLowerCase = role.toLowerCase();
+		switch (roleLowerCase) {
+		case "partner":
+			if (!AdminTestUtil.isValidToken(partnerCookie)) {
+				partnerCookie = getAuthTokenFromKeyCloak(ConfigManager.getPmsClientId(),
+						ConfigManager.getPmsClientSecret());
+			}
+			return partnerCookie;
+		case "mobileauth":
+			if (!AdminTestUtil.isValidToken(mobileAuthCookie)) {
+				mobileAuthCookie = getAuthTokenFromKeyCloak(ConfigManager.getMPartnerMobileClientId(),
+						ConfigManager.getMPartnerMobileClientSecret());
+			}
+			return mobileAuthCookie;
+		default:
+			return "";
+		}
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Move common JWT decode utilities from EsignetUtil to AdminTestUtil

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role-based Keycloak token retrieval and caching to streamline authenticated API access.
  * PATCH requests can now include bearer-token authentication with path parameters.
  * Utility to decode URL-safe Base64 values.
  * Utility to decode and combine JWT header and payload into a single JSON view for easier inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->