### PR TITLE
Avoid unnecessary report content in validateResponse for non-IDA-MLC-018 responses.

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -7771,7 +7771,7 @@ public class AdminTestUtil extends BaseTestCase {
 	            logger.error("UIN not found in input JSON");
 	        }
 	    }
-	    return "Response is null or No IDA-MLC-018 error found in response";
+	    return "";
 	}
 	
 	public static String extractIdValue(String json) {


### PR DESCRIPTION
Updated validateResponse() to return an empty string when the response is null or does not contain IDA-MLC-018, instead of returning a default message.