### PR TITLE
MOSIP-40953: Update eSignet health check URL to public endpoint and improve configurability.

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/HealthChecker.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/HealthChecker.java
@@ -70,8 +70,16 @@ public class HealthChecker implements Runnable {
 										&& (ConfigManager.isInServiceNotDeployedList(GlobalConstants.RID_GENERATOR))) {
 							continue;
 						}
-						String baseUrl = parts[1].contains(GlobalConstants.ESIGNET) ? ConfigManager.getEsignetBaseUrl()
-								: BaseTestCase.ApplnURI;
+						String baseUrl = BaseTestCase.ApplnURI;
+						if (parts[1].contains(GlobalConstants.ESIGNET)) {
+							String esignetBaseUrl = ConfigManager.getEsignetBaseUrl();
+							if (esignetBaseUrl != null && !esignetBaseUrl.trim().isEmpty()) {
+								baseUrl = esignetBaseUrl;
+							} else {
+								logger.error("Missing eSignetbaseurl. Falling back to BaseTestCase.ApplnURI for "
+										+ parts[1]);
+							}
+						}
 						controllerPaths.add(baseUrl + parts[1]);
 					}
 				}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/HealthChecker.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/HealthChecker.java
@@ -63,15 +63,16 @@ public class HealthChecker implements Runnable {
 					// only add health check required for the current running module
 					if (parts[0].contains(currentRunningModule)) {
 						if (parts[1].contains(GlobalConstants.ESIGNET)
-								&& (ConfigManager.isInServiceNotDeployedList(GlobalConstants.ESIGNET)))
+								&& (ConfigManager.isInServiceNotDeployedList(GlobalConstants.ESIGNET))
+								|| parts[1].contains(GlobalConstants.RESIDENT)
+										&& (ConfigManager.isInServiceNotDeployedList(GlobalConstants.RESIDENT))
+								|| parts[1].contains(GlobalConstants.RID_GENERATOR)
+										&& (ConfigManager.isInServiceNotDeployedList(GlobalConstants.RID_GENERATOR))) {
 							continue;
-						if (parts[1].contains(GlobalConstants.RESIDENT)
-								&& (ConfigManager.isInServiceNotDeployedList(GlobalConstants.RESIDENT)))
-							continue;
-						if (parts[1].contains(GlobalConstants.RID_GENERATOR)
-								&& (ConfigManager.isInServiceNotDeployedList(GlobalConstants.RID_GENERATOR)))
-							continue;
-						controllerPaths.add(BaseTestCase.ApplnURI + parts[1]);
+						}
+						String baseUrl = parts[1].contains(GlobalConstants.ESIGNET) ? ConfigManager.getEsignetBaseUrl()
+								: BaseTestCase.ApplnURI;
+						controllerPaths.add(baseUrl + parts[1]);
 					}
 				}
 			}


### PR DESCRIPTION
- Updated logic to use public load-balanced URL for eSignet
- Introduced dynamic base URL selection:
eSignet → ConfigManager.getEsignetBaseUrl()
Other services → BaseTestCase.ApplnURI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated health-check skip logic for specific endpoints to simplify checks.
  * Improved base URL selection for health checks with special handling for the esignet service, including fallback behavior and error logging when needed.
  * Built endpoint list using the selected base URL to ensure correct endpoint construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->