### PR TITLE
MOSIP-44709: Add helper variables and keyword handlers for Data Share Policy in Esignet.

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/BaseTestCase.java
@@ -153,18 +153,23 @@ public class BaseTestCase {
 	public static String genPolicyNumber = "9" + generateRandomNumberString(5);
 	public static String genRidDel = "2785" + generateRandomNumberString(10);
 	public String genPolicyGroupDesc = "policyGroupForAutomationEsi" + generateRandomNumberString(6);
+	public String genDataSharePolicyGroupDesc = "policyGroupForDataSharePolicyEsi" + generateRandomNumberString(6);
 	public String genMispPolicyGroupDesc = "policyGroupForMispEsi" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
 	public String genPolicyGroupName = "policyGroupNameForAutomationEsi" + generateRandomNumberString(5);
+	public String genDataSharePolicyGroupName = "policyGroupNameForDataShareEsi" + generateRandomNumberString(5);
 	public String genMispPolicyGroupName = "policyGroupNameForMispEsi" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
 	public String genPolicyDesc = "policyDescForAutomationEsi" + generateRandomNumberString(5);
+	public String genDataSharePolicyDesc = "policyDescForDataShareEsi" + generateRandomNumberString(5);
 	public String genMispPolicyDesc = "policyDescForMispEsit" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
 	public String genPolicyName = "policyNameForAutomationEsi" + generateRandomNumberString(4);
 	public String genPolicyNameNonAuth = "policyNameForEsignet" + generateRandomNumberString(4);
 	public String genMispPolicyName = "policyNameForMispEsi" + generateRandomNumberString(6)
 			+ generateRandomNumberString(3);
+	public String genDataSharePolicyName = "policyNameForDataShareEsi" + generateRandomNumberString(6)
+	+ generateRandomNumberString(3);
 	public static String genPartnerName = null;
 	public static String genPartnerNameNonAuth = null;
 	public String genPartnerNameForDsl = "partnernameforautomationdsl-" + generateRandomNumberString(6);
@@ -178,6 +183,8 @@ public class BaseTestCase {
 			+ "@automationMosip.com";
 	public String genMispPartnerEmail = "misppartner" + generateRandomNumberString(4) + generateRandomNumberString(4)
 			+ "@automationMosip.com";
+	public String genDataSharePartnerEmail = "datasharepartner" + generateRandomNumberString(4) + generateRandomNumberString(4)
+	+ "@automationMosip.com";
 	public static String publickey;
 	public static RSAKey rsaJWK;
 	public static String clientAssertionToken;

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -4125,6 +4125,21 @@ public class AdminTestUtil extends BaseTestCase {
 
 		if (jsonString.contains("$MISPPARTNEREMAIL$"))
 			jsonString = replaceKeywordWithValue(jsonString, "$MISPPARTNEREMAIL$", genMispPartnerEmail);
+		
+		if (jsonString.contains("$DATASHAREPARTNEREMAIL$"))
+			jsonString = replaceKeywordWithValue(jsonString, "$DATASHAREPARTNEREMAIL$", genDataSharePartnerEmail);
+		
+		if (jsonString.contains("$DATASHAREPOLICYDESC$"))
+			jsonString = replaceKeywordWithValue(jsonString, "$DATASHAREPOLICYDESC$", genDataSharePolicyDesc);
+		
+		if (jsonString.contains("$DATASHAREPOLICYNAME$"))
+			jsonString = replaceKeywordWithValue(jsonString, "$DATASHAREPOLICYNAME$", genDataSharePolicyName);
+		
+		if (jsonString.contains("$DATASHAREPOLICYGROUPDESC$"))
+			jsonString = replaceKeywordWithValue(jsonString, "$DATASHAREPOLICYGROUPDESC$", genDataSharePolicyGroupDesc);
+
+		if (jsonString.contains("$DATASHAREPOLICYGROUPNAME$"))
+			jsonString = replaceKeywordWithValue(jsonString, "$DATASHAREPOLICYGROUPNAME$", genDataSharePolicyGroupName);
 
 		if (jsonString.contains("$ZONE_CODE$"))
 			jsonString = replaceKeywordWithValue(jsonString, "$ZONE_CODE$", ZonelocationCode);


### PR DESCRIPTION
Dynamic variable generation and corresponding JSON keyword handling support for Data Share Policy functional testing. These changes allow automation scripts to dynamically replace placeholder tokens in test payloads with randomized, unique strings.