### PR TITLE
MOSIP-45087 - Updated the regex for fetching OTP from SMTP

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/OTPListener.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/testrunner/OTPListener.java
@@ -256,11 +256,11 @@ public class OTPListener {
 									.get(30, TimeUnit.SECONDS);
 							logger.info("WebSocket reconnected successfully on attempt " + attempt);
 							reconnectEvents.add("WebSocket reconnected successfully on attempt "
-									+ attempt + " at " + java.time.LocalDateTime.now());
+									+ attempt + " at " + java.time.Instant.now() + " UTC");
 							return;
 						} catch (Exception e) {
 							String failMsg = "WebSocket reconnect attempt " + attempt + " failed: "
-									+ e.getMessage() + " at " + java.time.LocalDateTime.now();
+									+ e.getMessage() + " at " + java.time.Instant.now() + " UTC";
 							logger.warn(failMsg + ". Retrying in "
 									+ Math.min(3000L * (attempt + 1), 60000L) + "ms...");
 							reconnectEvents.add(failMsg);

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalMethods.java
@@ -129,7 +129,7 @@ public class GlobalMethods {
 		}
 
 		// Both RegEx didn't match.. Needs revisit..
-		logger.error("Needs RegEx revisit..." + "url is:" + url);
+		logger.debug("Needs RegEx revisit..." + "url is:" + url);
 		return url;
 	}
 

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/NotificationListener.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/NotificationListener.java
@@ -22,7 +22,7 @@ public final class NotificationListener {
 			"(?i)(?:" +
 			"\\bis\\s+(\\d{6})\\s+and\\s+is\\s+valid" +   // English: "is XXXXXX and is valid"
 			"|\\buse\\s+(?:otp\\s+)?(\\d{6})\\b" +        // English: "Use [OTP] XXXXXX"
-			"|\\bOTP\\b.*?(\\d{6})(?!\\d)" +              // Multilingual: OTP keyword + nearest 6 digits
+			"|\\bOTP\\b.*?\\b(\\d{6})\\b" +               // Multilingual: OTP keyword + standalone 6 digits
 			")");
 	private static final ConcurrentHashMap<String, EmailQueue> otpQueues = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
MOSIP-45087 - Updated the regex for fetching OTP from SMTP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP detection accuracy with enhanced pattern matching for better digit recognition.
  * Corrected timestamp formatting in WebSocket reconnection logs to use explicit UTC timezone reference.
  * Adjusted log level for fallback endpoint URL handling messages for more appropriate severity classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->