### PR TITLE
MOSIP-45003: Fix Handlebars escaping, correct JSON array tags, and add modifySchemaGenerateHbsV2.

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -6157,7 +6157,7 @@ public class AdminTestUtil extends BaseTestCase {
 					if (eachRequiredProp.equals(emailFieldName)) {
 						entry.put("value", "$EMAILVALUE$"); entry.put("tags", new JSONArray().put("handle"));
 					} else if (eachRequiredProp.equals(phoneFieldName)) {
-						entry.put("value", "$PHONENUMBERFORIDENTITY$"); entry.put("tags", new JSONArray().put("handle"));
+						entry.put("value", "{{phone}}"); entry.put("tags", new JSONArray().put("handle"));
 					} else {
 						entry.put("value", "$FUNCTIONALID$"); entry.put("tags", new JSONArray().put("handle"));
 					}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -98,7 +98,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.Template;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -3816,8 +3819,16 @@ public class AdminTestUtil extends BaseTestCase {
 
 	}
 
-	public static Handlebars handlebars = new Handlebars();
+	public static Handlebars handlebars = new Handlebars().with(EscapingStrategy.NOOP);
 	public static Gson gson = new Gson();
+	static {
+		handlebars.registerHelper("json", new Helper<Object>() {
+			@Override
+			public CharSequence apply(Object context, Options options) {
+				return gson.toJson(context);
+			}
+		});
+	}
 
 	public String getJsonFromTemplate(String input, String template, boolean readFile) {
 		String resultJson = null;
@@ -5630,6 +5641,31 @@ public class AdminTestUtil extends BaseTestCase {
 		identityHbs = requestJson.toString();
 		return identityHbs;
 	}
+	
+	public static String modifySchemaGenerateHbsV2(boolean regenerateHbs) {
+
+		String hbs = modifySchemaGenerateHbs(regenerateHbs);
+
+		JSONObject requestJson = new JSONObject(hbs);
+		requestJson.getJSONObject("request").put("verifiedAttributes", "$VERIFIED_ATTRIBUTES$");
+
+		return requestJson.toString().replace("\"$VERIFIED_ATTRIBUTES$\"", buildVerifiedAttributesHbs());
+	}
+	
+	private static String buildVerifiedAttributesHbs() {
+
+	    return "{{{json verifiedAttributes}}}";
+	}
+
+	/*
+	 * private static String buildVerifiedAttributesHbs() { return
+	 * "[{{#each verifiedAttributes}}" + "{{#unless @first}},{{/unless}}" + "{" +
+	 * "\"trustFramework\":\"{{trustFramework}}\"," +
+	 * "\"verificationProcess\":\"{{verificationProcess}}\"," +
+	 * "\"claims\":[{{#each claims}}{{#unless @first}},{{/unless}}\"{{this}}\"{{/each}}]"
+	 * + "{{#if metadata}},\"metadata\":{{json metadata}}{{/if}}" + "}" +
+	 * "{{/each}}]"; }
+	 */
 
 	public static String getSchemaURL() {
 		String schemaURL = ApplnURI + properties.getProperty(GlobalConstants.MASTER_SCHEMA_URL);

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -98,10 +98,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.jknack.handlebars.Context;
-import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
-import com.github.jknack.handlebars.Helper;
-import com.github.jknack.handlebars.Options;
 import com.github.jknack.handlebars.Template;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -128,6 +125,9 @@ import io.mosip.testrig.apirig.testrunner.MessagePrecondtion;
 import io.mosip.testrig.apirig.testrunner.OTPListener;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import com.github.jknack.handlebars.EscapingStrategy;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
 
 /**
  * @author Ravi Kant
@@ -5670,16 +5670,6 @@ public class AdminTestUtil extends BaseTestCase {
 	    return "{{{json verifiedAttributes}}}";
 	}
 
-	private static boolean isArrayHandleType(JSONObject eachPropDataJson) {
-		if (!eachPropDataJson.has("$ref")) {
-			return false;
-		}
-
-		String ref = eachPropDataJson.optString("$ref", "").toLowerCase();
-		return ref.contains("taggedlisttype") || ref.contains("simplelisttype")
-				|| (ref.contains("listtype") && eachPropDataJson.optBoolean("handle", false));
-	}
-	
 	public static String getSchemaURL() {
 		String schemaURL = ApplnURI + properties.getProperty(GlobalConstants.MASTER_SCHEMA_URL);
 		String schemaVersion = ConfigManager.getproperty(GlobalConstants.SCHEMA_VERSION);
@@ -5928,7 +5918,7 @@ public class AdminTestUtil extends BaseTestCase {
 			requestJson.put("registrationId", "{{registrationId}}");
 			JSONObject identityJson = new JSONObject();
 			JSONArray handleArray = new JSONArray();
-			handleArray.put("handles");
+			handleArray.put("handle");
 			List<String> selectedHandles = new ArrayList<>();
 
 			for (int i = 0, size = requiredPropsArray.length(); i < size; i++) {
@@ -6165,11 +6155,11 @@ public class AdminTestUtil extends BaseTestCase {
 					JSONArray arr = new JSONArray();
 					JSONObject entry = new JSONObject();
 					if (eachRequiredProp.equals(emailFieldName)) {
-						entry.put("value", "$EMAILVALUE$"); entry.put("tags", new JSONArray().put("handles"));
+						entry.put("value", "$EMAILVALUE$"); entry.put("tags", new JSONArray().put("handle"));
 					} else if (eachRequiredProp.equals(phoneFieldName)) {
-						entry.put("value", "{{phone}}"); entry.put("tags", new JSONArray().put("handles"));
+						entry.put("value", "$PHONENUMBERFORIDENTITY$"); entry.put("tags", new JSONArray().put("handle"));
 					} else {
-						entry.put("value", "$FUNCTIONALID$"); entry.put("tags", new JSONArray().put("handles"));
+						entry.put("value", "$FUNCTIONALID$"); entry.put("tags", new JSONArray().put("handle"));
 					}
 					arr.put(entry);
 					identityJson.put(eachRequiredProp, arr);
@@ -6202,7 +6192,7 @@ public class AdminTestUtil extends BaseTestCase {
 						if ("array".equals(fieldType)) {
 							JSONArray emailArray = new JSONArray();
 							JSONObject emailEntry = new JSONObject();
-							emailEntry.put("value", "$EMAILVALUE$"); emailEntry.put("tags", new JSONArray().put("handles"));
+							emailEntry.put("value", "$EMAILVALUE$"); emailEntry.put("tags", new JSONArray().put("handle"));
 							emailArray.put(emailEntry); identityJson.put(eachRequiredProp, emailArray);
 						} else {
 							identityJson.put(eachRequiredProp, "$EMAILVALUE$");

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -5848,6 +5848,16 @@ public class AdminTestUtil extends BaseTestCase {
 		updateIdentityHbs = requestJson.toString();
 		return updateIdentityHbs;
 	}
+	
+	public static String updateIdentityHbsV2(boolean regenerateHbs) {
+
+		String hbs = updateIdentityHbs(regenerateHbs);
+
+		JSONObject requestJson = new JSONObject(hbs);
+		requestJson.getJSONObject("request").put("verifiedAttributes", "$VERIFIED_ATTRIBUTES$");
+
+		return requestJson.toString().replace("\"$VERIFIED_ATTRIBUTES$\"", buildVerifiedAttributesHbs());
+	}
 
 	public static String generateLatestSchemaVersion() {
 		kernelAuthLib = new KernelAuthentication();

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -5657,16 +5657,6 @@ public class AdminTestUtil extends BaseTestCase {
 	    return "{{{json verifiedAttributes}}}";
 	}
 
-	/*
-	 * private static String buildVerifiedAttributesHbs() { return
-	 * "[{{#each verifiedAttributes}}" + "{{#unless @first}},{{/unless}}" + "{" +
-	 * "\"trustFramework\":\"{{trustFramework}}\"," +
-	 * "\"verificationProcess\":\"{{verificationProcess}}\"," +
-	 * "\"claims\":[{{#each claims}}{{#unless @first}},{{/unless}}\"{{this}}\"{{/each}}]"
-	 * + "{{#if metadata}},\"metadata\":{{json metadata}}{{/if}}" + "}" +
-	 * "{{/each}}]"; }
-	 */
-
 	public static String getSchemaURL() {
 		String schemaURL = ApplnURI + properties.getProperty(GlobalConstants.MASTER_SCHEMA_URL);
 		String schemaVersion = ConfigManager.getproperty(GlobalConstants.SCHEMA_VERSION);

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -5463,7 +5463,7 @@ public class AdminTestUtil extends BaseTestCase {
 			JSONObject identityJson = new JSONObject();
 			identityJson.put("UIN", "{{UIN}}");
 			JSONArray handleArray = new JSONArray();
-			handleArray.put("handles");
+			handleArray.put("handle");
 
 			List<String> selectedHandles = new ArrayList<>();
 			// requiredPropsArray.put("functionalId");
@@ -5483,9 +5483,8 @@ public class AdminTestUtil extends BaseTestCase {
 					randomValue = phoneSchemaRegex;
 				}
 
-				// Processing for TaggedListType
-				if (eachPropDataJson.has("$ref")
-						&& eachPropDataJson.get("$ref").toString().contains("TaggedListType")) {
+				// Processing for array handle types such as TaggedListType and simpleListType.
+				if (isArrayHandleType(eachPropDataJson)) {
 					JSONArray eachPropDataArrayForHandles = new JSONArray();
 					JSONObject eachValueJsonForHandles = new JSONObject();
 					if (eachRequiredProp.equals(emailResult)) {
@@ -5657,6 +5656,16 @@ public class AdminTestUtil extends BaseTestCase {
 	    return "{{{json verifiedAttributes}}}";
 	}
 
+	private static boolean isArrayHandleType(JSONObject eachPropDataJson) {
+		if (!eachPropDataJson.has("$ref")) {
+			return false;
+		}
+
+		String ref = eachPropDataJson.optString("$ref", "").toLowerCase();
+		return ref.contains("taggedlisttype") || ref.contains("simplelisttype")
+				|| (ref.contains("listtype") && eachPropDataJson.optBoolean("handle", false));
+	}
+	
 	public static String getSchemaURL() {
 		String schemaURL = ApplnURI + properties.getProperty(GlobalConstants.MASTER_SCHEMA_URL);
 		String schemaVersion = ConfigManager.getproperty(GlobalConstants.SCHEMA_VERSION);
@@ -5726,7 +5735,7 @@ public class AdminTestUtil extends BaseTestCase {
 			JSONObject identityJson = new JSONObject();
 			identityJson.put("UIN", "{{UIN}}");
 			JSONArray handleArray = new JSONArray();
-			handleArray.put("handles");
+			handleArray.put("handle");
 
 			List<String> selectedHandles = new ArrayList<>();
 			// requiredPropsArray.put("functionalId");
@@ -5746,9 +5755,8 @@ public class AdminTestUtil extends BaseTestCase {
 					randomValue = phoneSchemaRegex;
 				}
 
-				// Processing for TaggedListType
-				if (eachPropDataJson.has("$ref")
-						&& eachPropDataJson.get("$ref").toString().contains("TaggedListType")) {
+				// Processing for array handle types such as TaggedListType and simpleListType.
+				if (isArrayHandleType(eachPropDataJson)) {
 					JSONArray eachPropDataArrayForHandles = new JSONArray();
 					JSONObject eachValueJsonForHandles = new JSONObject();
 					if (eachRequiredProp.equals(emailResult)) {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -5745,19 +5745,26 @@ public class AdminTestUtil extends BaseTestCase {
 				boolean isHandle = eachPropDataJson.optBoolean("handle", false);
 
 				if (!ref.isEmpty() && ref.contains("TaggedListType")) {
-					JSONArray arr = new JSONArray();
-					JSONObject entry = new JSONObject();
+					// Legacy: backward compatibility for schemas using TaggedListType $ref
+					JSONArray eachPropDataArrayForHandles = new JSONArray();
+					JSONObject eachValueJsonForHandles = new JSONObject();
 					if (eachRequiredProp.equals(emailFieldName)) {
-						entry.put("value", "$EMAILVALUE$"); entry.put("tags", handleArray); selectedHandles.add(emailFieldName);
+						eachValueJsonForHandles.put("value", "{{" + eachRequiredProp + "}}");
+						eachValueJsonForHandles.put("tags", handleArray);
+						selectedHandles.add(emailFieldName);
 					} else if (eachRequiredProp.equals(phoneFieldName)) {
-						entry.put("value", "{{phone}}"); entry.put("tags", handleArray); selectedHandles.add(phoneFieldName);
+						eachValueJsonForHandles.put("value", "{{phone}}");
+						eachValueJsonForHandles.put("tags", handleArray);
+						selectedHandles.add(phoneFieldName);
 					} else {
-						entry.put("value", "$FUNCTIONALID$"); entry.put("tags", handleArray); selectedHandles.add(eachRequiredProp);
+						eachValueJsonForHandles.put("value", "$FUNCTIONALID$");
+						eachValueJsonForHandles.put("tags", handleArray);
+						selectedHandles.add(eachRequiredProp);
 					}
-					arr.put(entry);
-					identityJson.put(eachRequiredProp, arr);
+					eachPropDataArrayForHandles.put(eachValueJsonForHandles);
+					identityJson.put(eachRequiredProp, eachPropDataArrayForHandles);
 
-				} else if (!ref.isEmpty() && ref.contains("simpleType")) {
+				}  else if (!ref.isEmpty() && ref.contains("simpleType")) {
 					if (isHandle) selectedHandles.add(eachRequiredProp);
 					JSONArray arr = new JSONArray();
 					for (int j = 0; j < BaseTestCase.getLanguageList().size(); j++) {
@@ -5804,18 +5811,27 @@ public class AdminTestUtil extends BaseTestCase {
 						else
 							identityJson.put(eachRequiredProp, "{{" + eachRequiredProp + "}}");
 					} else if (eachRequiredProp.equals(phoneFieldName)) {
-						if (isHandle) selectedHandles.add(eachRequiredProp);
+						if (isHandle) {
+							selectedHandles.add(eachRequiredProp);
+						}
 						identityJson.put(eachRequiredProp, "{{phone}}");
+
 					} else if (eachRequiredProp.equals(emailFieldName)) {
-						if (isHandle) selectedHandles.add(eachRequiredProp);
+						if (isHandle) {
+							selectedHandles.add(eachRequiredProp);
+						}
 						if ("array".equals(fieldType)) {
+							// Inline array handle (e.g. schema where email is type:array + handle:true)
 							JSONArray emailArray = new JSONArray();
 							JSONObject emailEntry = new JSONObject();
-							emailEntry.put("value", "$EMAILVALUE$"); emailEntry.put("tags", handleArray);
-							emailArray.put(emailEntry); identityJson.put(eachRequiredProp, emailArray);
+							emailEntry.put("value", "{{" + eachRequiredProp + "}}");
+							emailEntry.put("tags", handleArray);
+							emailArray.put(emailEntry);
+							identityJson.put(eachRequiredProp, emailArray);
 						} else {
-							identityJson.put(eachRequiredProp, "$EMAILVALUE$");
+							identityJson.put(eachRequiredProp, "{{" + eachRequiredProp + "}}");
 						}
+
 					} else if ("array".equals(fieldType) && isHandle) {
 						JSONArray arrayHandle = new JSONArray();
 						JSONObject handleEntry = new JSONObject();

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalConstants.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/GlobalConstants.java
@@ -259,6 +259,8 @@ public class GlobalConstants {
 	public static final String SESSION = "SESSION";
 	public static final String COOKIE_NAME = "cookieName";
 	public static final String ACCEPT_HEADER = "acceptHeader";
+	
+	public static final String ADD_IDENTITY_V2_ENDPOINT = "/v1/identity/v2";
 
 	public static final String ACTIVE_PROFILES = "activeProfiles";
 


### PR DESCRIPTION
- **Handlebars Updates:** Configured EscapingStrategy.NOOP to prevent HTML escaping and registered a custom {{json}} helper to safely serialize object contexts via Gson.
- **Schema Generation:** Added modifySchemaGenerateHbsV2() which dynamically injects unescaped {{{json verifiedAttributes}}} blocks into the schema.
- **Tag Correction:** Replaced incorrect "handles" string values with the singular "handle" across multiple test rig utility methods (modifySchemaGenerateHbs, updateIdentityHbs, generateHbsForUpdateDraft, and generateHbsForPrereg) to align with validation rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the new Identity V2 endpoint (v1/identity/v2).
* **Tests**
  * Enhanced schema template generation with improved handling for verified attributes.
  * Optimized template engine configuration for more reliable JSON serialization in test validation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->