### PR TITLE
MOSIP-45253 - updated the utilities for updating Identity for array handles

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -2564,14 +2564,18 @@ public class AdminTestUtil extends BaseTestCase {
 		JSONObject req = new JSONObject(inputJson);
 		HashMap<String, String> pathParamsMap = new HashMap<>();
 		String[] params = pathParams.split(",");
+		JSONObject nestedRequest = (req.has(GlobalConstants.REQUEST)
+				&& req.get(GlobalConstants.REQUEST) instanceof JSONObject)
+						? req.getJSONObject(GlobalConstants.REQUEST)
+						: null;
 		for (String param : params) {
 			if (req.has(param)) {
 				pathParamsMap.put(param, req.get(param).toString());
 				req.remove(param);
-			} else if (req.has(GlobalConstants.REQUEST) && req.getJSONObject(GlobalConstants.REQUEST).has(param)) {
+			} else if (nestedRequest != null && nestedRequest.has(param)) {
 				// Schema-driven request bodies nest fields (e.g. registrationId) under "request";
 				// keep it there for the body, only borrow the value for the URL path param.
-				pathParamsMap.put(param, req.getJSONObject(GlobalConstants.REQUEST).get(param).toString());
+				pathParamsMap.put(param, nestedRequest.get(param).toString());
 			} else
 				logger.error(GlobalConstants.ERROR_STRING_2 + param + GlobalConstants.IN_STRING + inputJson);
 		}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -2568,6 +2568,10 @@ public class AdminTestUtil extends BaseTestCase {
 			if (req.has(param)) {
 				pathParamsMap.put(param, req.get(param).toString());
 				req.remove(param);
+			} else if (req.has(GlobalConstants.REQUEST) && req.getJSONObject(GlobalConstants.REQUEST).has(param)) {
+				// Schema-driven request bodies nest fields (e.g. registrationId) under "request";
+				// keep it there for the body, only borrow the value for the URL path param.
+				pathParamsMap.put(param, req.getJSONObject(GlobalConstants.REQUEST).get(param).toString());
 			} else
 				logger.error(GlobalConstants.ERROR_STRING_2 + param + GlobalConstants.IN_STRING + inputJson);
 		}
@@ -5455,6 +5459,7 @@ public class AdminTestUtil extends BaseTestCase {
 
 			requestJson.put("id", "{{id}}");
 			requestJson.put("request", new HashMap<>());
+			requestJson.getJSONObject("request").put("status", "ACTIVATED");
 			requestJson.getJSONObject("request").put("registrationId", "{{registrationId}}");
 			JSONObject identityJson = new JSONObject();
 			identityJson.put("UIN", "{{UIN}}");
@@ -5730,8 +5735,8 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 
 			requestJson.put("id", "{{id}}");
-			requestJson.put("status", "{{status}}");
 			requestJson.put("request", new HashMap<>());
+			requestJson.getJSONObject("request").put("status", "{{status}}");
 			requestJson.getJSONObject("request").put("registrationId", "{{registrationId}}");
 			JSONObject identityJson = new JSONObject();
 			identityJson.put("UIN", "{{UIN}}");
@@ -5950,7 +5955,8 @@ public class AdminTestUtil extends BaseTestCase {
 			requestJson.put("requesttime", "{{requesttime}}");
 			requestJson.put("version", "{{version}}");
 			requestJson.put("request", new HashMap<>());
-			requestJson.put("registrationId", "{{registrationId}}");
+			requestJson.getJSONObject("request").put("status", "ACTIVATED");
+			requestJson.getJSONObject("request").put("registrationId", "{{registrationId}}");
 			JSONObject identityJson = new JSONObject();
 			JSONArray handleArray = new JSONArray();
 			handleArray.put("handle");

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -5730,7 +5730,7 @@ public class AdminTestUtil extends BaseTestCase {
 			}
 
 			requestJson.put("id", "{{id}}");
-			requestJson.put("status", "ACTIVATED");
+			requestJson.put("status", "{{status}}");
 			requestJson.put("request", new HashMap<>());
 			requestJson.getJSONObject("request").put("registrationId", "{{registrationId}}");
 			JSONObject identityJson = new JSONObject();

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/NotificationListener.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/NotificationListener.java
@@ -23,6 +23,7 @@ public final class NotificationListener {
 			"\\bis\\s+(\\d{6})\\s+and\\s+is\\s+valid" +   // English: "is XXXXXX and is valid"
 			"|\\buse\\s+(?:otp\\s+)?(\\d{6})\\b" +        // English: "Use [OTP] XXXXXX"
 			"|\\bOTP\\b.*?\\b(\\d{6})\\b" +               // Multilingual: OTP keyword + standalone 6 digits
+			"|\\b(\\d{6})\\b" +                           // Fallback: fully-translated templates (e.g. Khmer) with no English anchor word, just the standalone 6-digit code
 			")");
 	private static final ConcurrentHashMap<String, EmailQueue> otpQueues = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
MOSIP-45253 - updated the utilities for updating Identity for array handles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP extraction so verification codes are recognized even when notification text contains only a standalone 6-digit number.
  * Fixed identity update and draft payload generation to correctly place `status` under the nested `request` object (using the provided value) and to better derive path parameters from nested request data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->