### PR TITLE
MOSIP-45308 - Created helper class for the Dynamic request body generation with full ID Schema

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dto/TestCaseDTO.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dto/TestCaseDTO.java
@@ -24,9 +24,6 @@ public class TestCaseDTO {
 	private String uniqueIdentifier;
 	private String additionalDependencies;
 	private String[] requiredSchemaFields;
-	// Field names that must be declared "handle": true in the live IdSchema for the test to apply.
-	// Skip-only: if a listed field is not a handle in the current schema, the test is skipped (never
-	// forced). Handle designation varies per schema (env/country), so a test that exercises a field's
-	// handle semantics is meaningful only where that field is actually a handle.
+	/** Field names that must be declared "handle":true in the live schema; the test is skipped otherwise. */
 	private String[] requiredHandleFields;
 }

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/dto/TestCaseDTO.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/dto/TestCaseDTO.java
@@ -24,4 +24,9 @@ public class TestCaseDTO {
 	private String uniqueIdentifier;
 	private String additionalDependencies;
 	private String[] requiredSchemaFields;
+	// Field names that must be declared "handle": true in the live IdSchema for the test to apply.
+	// Skip-only: if a listed field is not a handle in the current schema, the test is skipped (never
+	// forced). Handle designation varies per schema (env/country), so a test that exercises a field's
+	// handle semantics is meaningful only where that field is actually a handle.
+	private String[] requiredHandleFields;
 }

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -3831,6 +3831,15 @@ public class AdminTestUtil extends BaseTestCase {
 
 	}
 
+	// A plain scalar field is emitted into the JSON tree as this sentinel first, then swapped for the
+	// {{schemaFieldValue "name"}} helper call once the JSON is fully built (finalizeSchemaGenericFields).
+	// It cannot be a raw Handlebars call inside the JSON because the helper's quoted argument would break
+	// any JSONObject re-parse (e.g. the V2 verifiedAttributes wrap).
+	public static final String SCHEMA_FIELD_HELPER = "schemaFieldValue";
+	public static final String SCHEMA_FIELD_SENTINEL_PREFIX = "$$SCHEMAFIELD:";
+	public static final String SCHEMA_FIELD_SENTINEL_SUFFIX = "$$";
+	private static final Pattern SCHEMA_FIELD_SENTINEL_PATTERN = Pattern.compile("\\$\\$SCHEMAFIELD:([A-Za-z0-9_]+)\\$\\$");
+
 	public static Handlebars handlebars = new Handlebars().with(EscapingStrategy.NOOP);
 	public static Gson gson = new Gson();
 	static {
@@ -3840,6 +3849,97 @@ public class AdminTestUtil extends BaseTestCase {
 				return gson.toJson(context);
 			}
 		});
+		// Presence-aware value for a plain scalar identity field: use whatever the YAML input supplies
+		// for the key (INCLUDING a deliberate "" that a negative test sends), and only generate a
+		// validator-valid value when the input omits the key entirely. This keeps AddIdentity working
+		// when a country/env schema adds or renames a scalar field no YAML mentions — without a fallback
+		// such a field would render as "" and fail the schema's own validation. Shared by
+		// modifySchemaGenerateHbs and the opt-in SchemaBasedIdentityTemplateBuilder.
+		handlebars.registerHelper(SCHEMA_FIELD_HELPER, new Helper<String>() {
+			@Override
+			public CharSequence apply(String fieldName, Options options) {
+				Object suppliedValue = options.get(fieldName);
+				if (suppliedValue != null) {
+					return suppliedValue.toString();
+				}
+				return generateSchemaFieldValue(fieldName);
+			}
+		});
+	}
+
+	/** Swaps each generic-field sentinel for the {{schemaFieldValue "name"}} helper call. */
+	public static String finalizeSchemaGenericFields(String json) {
+		if (json == null || json.indexOf(SCHEMA_FIELD_SENTINEL_PREFIX) < 0) {
+			return json;
+		}
+		Matcher matcher = SCHEMA_FIELD_SENTINEL_PATTERN.matcher(json);
+		StringBuffer sb = new StringBuffer();
+		while (matcher.find()) {
+			matcher.appendReplacement(sb,
+					Matcher.quoteReplacement("{{" + SCHEMA_FIELD_HELPER + " \"" + matcher.group(1) + "\"}}"));
+		}
+		matcher.appendTail(sb);
+		return sb.toString();
+	}
+
+	/**
+	 * Generates a value satisfying the given schema field's own validator (random alphanumeric fallback
+	 * when it has none). Used as the presence-aware fallback for a scalar field the YAML doesn't supply,
+	 * and for resolving $HANDLEVALUE:&lt;field&gt;$ tokens.
+	 */
+	public static String generateSchemaFieldValue(String fieldName) {
+		JSONObject props = getIdentitySchemaProperties();
+		String regex = null;
+		if (props.has(fieldName)) {
+			JSONObject fieldDef = props.getJSONObject(fieldName);
+			if ("array".equals(fieldDef.optString("type", "string"))) {
+				JSONObject itemsDef = fieldDef.optJSONObject("items");
+				JSONObject valueDef = itemsDef != null && itemsDef.optJSONObject("properties") != null
+						? itemsDef.getJSONObject("properties").optJSONObject("value")
+						: null;
+				JSONArray validators = valueDef != null ? valueDef.optJSONArray("validators") : null;
+				if (validators != null && validators.length() > 0) {
+					regex = validators.getJSONObject(0).getString("validator");
+				}
+			} else {
+				JSONArray validators = fieldDef.optJSONArray("validators");
+				if (validators != null && validators.length() > 0) {
+					regex = validators.getJSONObject(0).getString("validator");
+				}
+			}
+		}
+		if (regex != null) {
+			try {
+				return genStringAsperRegex(regex);
+			} catch (Exception e) {
+				logger.error(e.getMessage());
+			}
+		}
+		return "mosip" + generateRandomNumberString(10);
+	}
+
+	/**
+	 * Resolves $HANDLEVALUE:&lt;fieldName&gt;$ tokens (emitted by the full-schema builder for optional
+	 * handle fields) into a fresh value valid for that field's validator. Called per request so handle
+	 * values stay unique across a run (the template is cached).
+	 */
+	public static String resolveSchemaHandleValueTokens(String jsonString) {
+		if (jsonString == null || !jsonString.contains("$HANDLEVALUE:")) {
+			return jsonString;
+		}
+		String token = "$HANDLEVALUE:";
+		int startIdx;
+		while ((startIdx = jsonString.indexOf(token)) != -1) {
+			int fieldStart = startIdx + token.length();
+			int endIdx = jsonString.indexOf("$", fieldStart);
+			if (endIdx == -1) {
+				break;
+			}
+			String fieldName = jsonString.substring(fieldStart, endIdx);
+			jsonString = jsonString.substring(0, startIdx) + generateSchemaFieldValue(fieldName)
+					+ jsonString.substring(endIdx + 1);
+		}
+		return jsonString;
 	}
 
 	public String getJsonFromTemplate(String input, String template, boolean readFile) {
@@ -5420,7 +5520,9 @@ public class AdminTestUtil extends BaseTestCase {
 
 	public static String modifySchemaGenerateHbs(boolean regenerateHbs) {
 		if (identityHbs != null && !regenerateHbs) {
-			return identityHbs;
+			// identityHbs is cached with generic-field sentinels (so modifySchemaGenerateHbsV2 can
+			// re-parse it as JSON); finalize turns them into the presence-aware helper on the way out.
+			return finalizeSchemaGenericFields(identityHbs);
 		}
 		JSONObject requestJson = new JSONObject();
 		kernelAuthLib = new KernelAuthentication();
@@ -5620,10 +5722,13 @@ public class AdminTestUtil extends BaseTestCase {
 								+ "}} — ensure YAML input supplies a value (e.g. a token like $NRCID$ or a literal).");
 
 					} else {
-						// Plain scalar field: always use {{placeholder}} so YAML can supply any value.
-						// Positive test YAMLs provide valid values; negative test YAMLs provide invalid ones.
-						// Baking propsMap/regex values here would prevent negative tests from overriding.
-						identityJson.put(eachRequiredProp, "{{" + eachRequiredProp + "}}");
+						// Plain scalar field: emit a sentinel that finalizeSchemaGenericFields turns into
+						// the presence-aware {{schemaFieldValue "field"}} helper — the YAML value if supplied
+						// (positive value, negative invalid value, deliberate "", or $REMOVE$), otherwise a
+						// validator-valid generated value so a required field the YAML never mentions (e.g.
+						// one a country/env schema adds) is never sent as an empty string.
+						identityJson.put(eachRequiredProp,
+								SCHEMA_FIELD_SENTINEL_PREFIX + eachRequiredProp + SCHEMA_FIELD_SENTINEL_SUFFIX);
 					}
 				}
 			}
@@ -5664,19 +5769,24 @@ public class AdminTestUtil extends BaseTestCase {
 			logger.error(e.getMessage());
 		}
 
+		// Cache WITH sentinels (valid JSON, so modifySchemaGenerateHbsV2 can re-parse); finalize on the
+		// way out into the presence-aware helper.
 		identityHbs = requestJson.toString();
-		return identityHbs;
+		return finalizeSchemaGenericFields(identityHbs);
 	}
-	
+
 	public static String modifySchemaGenerateHbsV2(boolean regenerateHbs) {
 		if (identityHbsV2 != null && !regenerateHbs) {
 			return identityHbsV2;
 		}
 		if (regenerateHbs) identityHbsV2 = null;
-		String hbs = modifySchemaGenerateHbs(regenerateHbs);
-		JSONObject requestJson = new JSONObject(hbs);
+		// Populate the cached sentinel template (identityHbs) then re-parse THAT — the sentinel form is
+		// valid JSON, unlike the finalized {{schemaFieldValue "x"}} form. Finalize after the V2 wrap.
+		modifySchemaGenerateHbs(regenerateHbs);
+		JSONObject requestJson = new JSONObject(identityHbs);
 		requestJson.getJSONObject("request").put("verifiedAttributes", "$VERIFIED_ATTRIBUTES$");
-		identityHbsV2 = requestJson.toString().replace("\"$VERIFIED_ATTRIBUTES$\"", buildVerifiedAttributesHbs());
+		identityHbsV2 = finalizeSchemaGenericFields(
+				requestJson.toString().replace("\"$VERIFIED_ATTRIBUTES$\"", buildVerifiedAttributesHbs()));
 		return identityHbsV2;
 	}
 	
@@ -8000,6 +8110,46 @@ public class AdminTestUtil extends BaseTestCase {
 
 		return globalRequiredFields;
 
+	}
+
+	public static JSONObject globalIdentityPropsJson = null;
+	// The live IdSchema identity node's "additionalProperties" flag, captured alongside the
+	// properties in getIdentitySchemaProperties() so callers can tell whether the schema rejects
+	// fields it doesn't define (strict) or accepts them (permissive). Boolean (not primitive) so
+	// null distinguishes "not fetched yet" from a real value.
+	public static Boolean globalIdentityAdditionalProperties = null;
+
+	/**
+	 * Returns the live IdSchema's full identity "properties" object (all fields,
+	 * not just the "required" ones), cached after the first fetch. Callers can
+	 * use this to inspect a field's "handle"/"type"/"validators" metadata
+	 * regardless of whether that field happens to be required — the required-only
+	 * loop in {@link #modifySchemaGenerateHbs(boolean)} intentionally does not
+	 * cover this, since its output is shared across modules that don't need it.
+	 */
+	public static JSONObject getIdentitySchemaProperties() {
+		if (globalIdentityPropsJson != null) {
+			return globalIdentityPropsJson;
+		}
+
+		kernelAuthLib = new KernelAuthentication();
+		String token = kernelAuthLib.getTokenByRole(GlobalConstants.ADMIN);
+		String url = getSchemaURL();
+
+		Response response = RestClient.getRequestWithCookie(url, MediaType.APPLICATION_JSON,
+				MediaType.APPLICATION_JSON, GlobalConstants.AUTHORIZATION, token);
+
+		org.json.JSONObject responseJson = new org.json.JSONObject(response.asString());
+		org.json.JSONObject schemaData = (org.json.JSONObject) responseJson.get(GlobalConstants.RESPONSE);
+		String schemaJsonData = schemaData.getString(GlobalConstants.SCHEMA_JSON);
+
+		JSONObject schemaFileJson = new JSONObject(schemaJsonData);
+		JSONObject schemaPropsJson = schemaFileJson.getJSONObject("properties");
+		JSONObject schemaIdentityJson = schemaPropsJson.getJSONObject("identity");
+		globalIdentityPropsJson = schemaIdentityJson.getJSONObject("properties");
+		globalIdentityAdditionalProperties = schemaIdentityJson.optBoolean("additionalProperties", false);
+
+		return globalIdentityPropsJson;
 	}
 
 	public static Response postWithJson(String endpoint, Object body) {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -3831,10 +3831,9 @@ public class AdminTestUtil extends BaseTestCase {
 
 	}
 
-	// A plain scalar field is emitted into the JSON tree as this sentinel first, then swapped for the
-	// {{schemaFieldValue "name"}} helper call once the JSON is fully built (finalizeSchemaGenericFields).
-	// It cannot be a raw Handlebars call inside the JSON because the helper's quoted argument would break
-	// any JSONObject re-parse (e.g. the V2 verifiedAttributes wrap).
+	// Scalar fields are emitted as this sentinel, then finalizeSchemaGenericFields swaps it for the
+	// {{schemaFieldValue "name"}} helper — kept as a sentinel until then so the JSON stays re-parsable
+	// (a raw helper call with a quoted arg would break any JSONObject re-parse, e.g. the V2 wrap).
 	public static final String SCHEMA_FIELD_HELPER = "schemaFieldValue";
 	public static final String SCHEMA_FIELD_SENTINEL_PREFIX = "$$SCHEMAFIELD:";
 	public static final String SCHEMA_FIELD_SENTINEL_SUFFIX = "$$";
@@ -3849,12 +3848,8 @@ public class AdminTestUtil extends BaseTestCase {
 				return gson.toJson(context);
 			}
 		});
-		// Presence-aware value for a plain scalar identity field: use whatever the YAML input supplies
-		// for the key (INCLUDING a deliberate "" that a negative test sends), and only generate a
-		// validator-valid value when the input omits the key entirely. This keeps AddIdentity working
-		// when a country/env schema adds or renames a scalar field no YAML mentions — without a fallback
-		// such a field would render as "" and fail the schema's own validation. Shared by
-		// modifySchemaGenerateHbs and the opt-in SchemaBasedIdentityTemplateBuilder.
+		// Renders a scalar identity field: the YAML value if the input supplies the key (including a
+		// deliberate ""), otherwise a validator-valid generated value so an unsupplied field is never "".
 		handlebars.registerHelper(SCHEMA_FIELD_HELPER, new Helper<String>() {
 			@Override
 			public CharSequence apply(String fieldName, Options options) {
@@ -5520,8 +5515,7 @@ public class AdminTestUtil extends BaseTestCase {
 
 	public static String modifySchemaGenerateHbs(boolean regenerateHbs) {
 		if (identityHbs != null && !regenerateHbs) {
-			// identityHbs is cached with generic-field sentinels (so modifySchemaGenerateHbsV2 can
-			// re-parse it as JSON); finalize turns them into the presence-aware helper on the way out.
+			// identityHbs is cached with sentinels; finalize on the way out (see the return below).
 			return finalizeSchemaGenericFields(identityHbs);
 		}
 		JSONObject requestJson = new JSONObject();
@@ -5722,11 +5716,8 @@ public class AdminTestUtil extends BaseTestCase {
 								+ "}} — ensure YAML input supplies a value (e.g. a token like $NRCID$ or a literal).");
 
 					} else {
-						// Plain scalar field: emit a sentinel that finalizeSchemaGenericFields turns into
-						// the presence-aware {{schemaFieldValue "field"}} helper — the YAML value if supplied
-						// (positive value, negative invalid value, deliberate "", or $REMOVE$), otherwise a
-						// validator-valid generated value so a required field the YAML never mentions (e.g.
-						// one a country/env schema adds) is never sent as an empty string.
+						// Plain scalar field: sentinel -> presence-aware {{schemaFieldValue}} helper, so a
+						// required field the YAML never supplies gets a valid value rather than "".
 						identityJson.put(eachRequiredProp,
 								SCHEMA_FIELD_SENTINEL_PREFIX + eachRequiredProp + SCHEMA_FIELD_SENTINEL_SUFFIX);
 					}
@@ -5769,9 +5760,7 @@ public class AdminTestUtil extends BaseTestCase {
 			logger.error(e.getMessage());
 		}
 
-		// Cache WITH sentinels (valid JSON, so modifySchemaGenerateHbsV2 can re-parse); finalize on the
-		// way out into the presence-aware helper.
-		identityHbs = requestJson.toString();
+		identityHbs = requestJson.toString(); // cached with sentinels; finalize on return
 		return finalizeSchemaGenericFields(identityHbs);
 	}
 
@@ -5780,8 +5769,7 @@ public class AdminTestUtil extends BaseTestCase {
 			return identityHbsV2;
 		}
 		if (regenerateHbs) identityHbsV2 = null;
-		// Populate the cached sentinel template (identityHbs) then re-parse THAT — the sentinel form is
-		// valid JSON, unlike the finalized {{schemaFieldValue "x"}} form. Finalize after the V2 wrap.
+		// Re-parse the cached sentinel form (valid JSON, unlike the finalized helper form); finalize after.
 		modifySchemaGenerateHbs(regenerateHbs);
 		JSONObject requestJson = new JSONObject(identityHbs);
 		requestJson.getJSONObject("request").put("verifiedAttributes", "$VERIFIED_ATTRIBUTES$");
@@ -8113,10 +8101,7 @@ public class AdminTestUtil extends BaseTestCase {
 	}
 
 	public static JSONObject globalIdentityPropsJson = null;
-	// The live IdSchema identity node's "additionalProperties" flag, captured alongside the
-	// properties in getIdentitySchemaProperties() so callers can tell whether the schema rejects
-	// fields it doesn't define (strict) or accepts them (permissive). Boolean (not primitive) so
-	// null distinguishes "not fetched yet" from a real value.
+	/** Identity node's "additionalProperties" flag (populated by getIdentitySchemaProperties); null until fetched. */
 	public static Boolean globalIdentityAdditionalProperties = null;
 
 	/**

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/AdminTestUtil.java
@@ -5768,7 +5768,6 @@ public class AdminTestUtil extends BaseTestCase {
 		if (identityHbsV2 != null && !regenerateHbs) {
 			return identityHbsV2;
 		}
-		if (regenerateHbs) identityHbsV2 = null;
 		// Re-parse the cached sentinel form (valid JSON, unlike the finalized helper form); finalize after.
 		modifySchemaGenerateHbs(regenerateHbs);
 		JSONObject requestJson = new JSONObject(identityHbs);
@@ -6272,7 +6271,6 @@ public class AdminTestUtil extends BaseTestCase {
 		if (updateIdentityHbsV2Cached != null && !regenerateHbs) {
 			return updateIdentityHbsV2Cached;
 		}
-		if (regenerateHbs) updateIdentityHbsV2Cached = null;
 		String hbs = updateIdentityHbs(regenerateHbs);
 		JSONObject requestJson = new JSONObject(hbs);
 		requestJson.getJSONObject("request").put("verifiedAttributes", "$VERIFIED_ATTRIBUTES$");

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SchemaBasedIdentityTemplateBuilder.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SchemaBasedIdentityTemplateBuilder.java
@@ -11,21 +11,16 @@ import org.json.JSONObject;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 
 /**
- * Opt-in builder that constructs the AddIdentity / UpdateIdentity request body from EVERY field in the
- * live IdSchema — both the "required" fields and the optional ones — unlike
- * {@link AdminTestUtil#modifySchemaGenerateHbs(boolean)}, which covers only the required set.
+ * Opt-in builder for the AddIdentity / UpdateIdentity request body from EVERY field in the live
+ * IdSchema — required and optional — unlike {@link AdminTestUtil#modifySchemaGenerateHbs(boolean)},
+ * which covers only the required set. Nothing wires this in by default; call it explicitly where a
+ * module needs the optional fields present (e.g. idrepo, which tests handle behaviour on optional
+ * handle fields). Modules that create an identity only as a prerequisite should keep using the
+ * required-only builder.
  *
- * <p>Use this where a module needs optional fields present in the identity it creates (e.g. idrepo,
- * which tests handle behaviour on optional handle fields such as licenseNo/functionalId). Most modules
- * create an identity only as a prerequisite for their own flow and should keep using the required-only
- * {@code modifySchemaGenerateHbs}; sending extra optional fields there is surface for their setup to
- * fail on with no benefit. Nothing here is wired into any module by default — call it explicitly.
- *
- * <p>The templates are deterministic per schema (every per-test value is a token/placeholder resolved
- * later at render time), so each variant is built once and cached for the run. Generic scalar fields use
- * the shared presence-aware {@code schemaFieldValue} helper (see AdminTestUtil); optional handle fields
- * use {@code $HANDLEVALUE:<field>$} tokens, which the caller resolves per request via
- * {@link AdminTestUtil#resolveSchemaHandleValueTokens(String)} so handle values stay unique across a run.
+ * <p>Templates are cached per run (deterministic per schema). Optional handle fields use
+ * {@code $HANDLEVALUE:<field>$} tokens; resolve them per request via
+ * {@link AdminTestUtil#resolveSchemaHandleValueTokens(String)} to keep handle values unique.
  */
 public class SchemaBasedIdentityTemplateBuilder {
 
@@ -111,9 +106,7 @@ public class SchemaBasedIdentityTemplateBuilder {
 				identityJson.put(fieldName, "$1STLANG$");
 
 			} else if (fieldName.equals("packetCreatedOn")) {
-				// System-populated audit timestamp with no $ref/validators; emit the $TIMESTAMP$ token so
-				// inputJsonKeyWordHandeler fills a fresh UTC time per request and this template stays
-				// deterministic (hence cacheable) rather than rendering "".
+				// System audit timestamp; $TIMESTAMP$ is filled per request by inputJsonKeyWordHandeler.
 				identityJson.put(fieldName, "$TIMESTAMP$");
 
 			} else if (!ref.isEmpty() && ref.contains("simpleType")) {
@@ -161,9 +154,7 @@ public class SchemaBasedIdentityTemplateBuilder {
 				identityJson.put(fieldName, hash);
 
 			} else if (fieldName.equals(phoneFieldName) || fieldName.equals(emailFieldName)) {
-				// Phone/email take their value from the YAML input ($PHONENUMBERFORIDENTITY$ / $EMAILVALUE$).
-				// Handled together and shape-driven so the two can't drift apart: whether either is a handle,
-				// and whether it is string or array, is per-schema. The phone placeholder is always {{phone}}.
+				// Handled together and shape-driven (string vs array is per-schema). Phone key is always {{phone}}.
 				String placeholder = fieldName.equals(phoneFieldName) ? "{{phone}}" : "{{" + fieldName + "}}";
 				if ("array".equals(fieldType)) {
 					JSONObject entry = new JSONObject();

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SchemaBasedIdentityTemplateBuilder.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SchemaBasedIdentityTemplateBuilder.java
@@ -1,0 +1,226 @@
+package io.mosip.testrig.apirig.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import io.mosip.testrig.apirig.testrunner.BaseTestCase;
+
+/**
+ * Opt-in builder that constructs the AddIdentity / UpdateIdentity request body from EVERY field in the
+ * live IdSchema — both the "required" fields and the optional ones — unlike
+ * {@link AdminTestUtil#modifySchemaGenerateHbs(boolean)}, which covers only the required set.
+ *
+ * <p>Use this where a module needs optional fields present in the identity it creates (e.g. idrepo,
+ * which tests handle behaviour on optional handle fields such as licenseNo/functionalId). Most modules
+ * create an identity only as a prerequisite for their own flow and should keep using the required-only
+ * {@code modifySchemaGenerateHbs}; sending extra optional fields there is surface for their setup to
+ * fail on with no benefit. Nothing here is wired into any module by default — call it explicitly.
+ *
+ * <p>The templates are deterministic per schema (every per-test value is a token/placeholder resolved
+ * later at render time), so each variant is built once and cached for the run. Generic scalar fields use
+ * the shared presence-aware {@code schemaFieldValue} helper (see AdminTestUtil); optional handle fields
+ * use {@code $HANDLEVALUE:<field>$} tokens, which the caller resolves per request via
+ * {@link AdminTestUtil#resolveSchemaHandleValueTokens(String)} so handle values stay unique across a run.
+ */
+public class SchemaBasedIdentityTemplateBuilder {
+
+	private static final Logger logger = Logger.getLogger(SchemaBasedIdentityTemplateBuilder.class);
+
+	private static String addTemplateCache = null;
+	private static String addTemplateV2Cache = null;
+	private static String updateTemplateCache = null;
+	private static String updateTemplateV2Cache = null;
+
+	private SchemaBasedIdentityTemplateBuilder() {
+	}
+
+	public static String buildAddIdentityTemplate() {
+		if (addTemplateCache == null) {
+			addTemplateCache = AdminTestUtil.finalizeSchemaGenericFields(buildTemplate(false));
+		}
+		return addTemplateCache;
+	}
+
+	public static String buildAddIdentityTemplateV2() {
+		if (addTemplateV2Cache == null) {
+			addTemplateV2Cache = AdminTestUtil.finalizeSchemaGenericFields(wrapV2(buildTemplate(false)));
+		}
+		return addTemplateV2Cache;
+	}
+
+	public static String buildUpdateIdentityTemplate() {
+		// Update flow emits bare {{field}} for generic fields (no sentinels), so finalize is a no-op.
+		if (updateTemplateCache == null) {
+			updateTemplateCache = buildTemplate(true);
+		}
+		return updateTemplateCache;
+	}
+
+	public static String buildUpdateIdentityTemplateV2() {
+		if (updateTemplateV2Cache == null) {
+			updateTemplateV2Cache = wrapV2(buildTemplate(true));
+		}
+		return updateTemplateV2Cache;
+	}
+
+	private static String wrapV2(String hbs) {
+		JSONObject requestJson = new JSONObject(hbs);
+		requestJson.getJSONObject("request").put("verifiedAttributes", "$$VERIFIED_ATTRIBUTES$$");
+		return requestJson.toString().replace("\"$$VERIFIED_ATTRIBUTES$$\"", "{{{json verifiedAttributes}}}");
+	}
+
+	private static String buildTemplate(boolean isUpdate) {
+		JSONObject props = AdminTestUtil.getIdentitySchemaProperties();
+		double schemaVersion = Double.parseDouble(AdminTestUtil.generateLatestSchemaVersion());
+
+		String phoneFieldName = AdminTestUtil.getValueFromAuthActuator("json-property", "phone_number")
+				.replaceAll("\\[\"|\"]", "");
+		String emailFieldName = AdminTestUtil.getValueFromAuthActuator("json-property", "emailId")
+				.replaceAll("\\[\"|\"]", "");
+
+		JSONObject requestJson = new JSONObject();
+		requestJson.put("id", "{{id}}");
+		requestJson.put("request", new JSONObject());
+		requestJson.getJSONObject("request").put("status", isUpdate ? "{{status}}" : "ACTIVATED");
+		requestJson.getJSONObject("request").put("registrationId", "{{registrationId}}");
+
+		JSONObject identityJson = new JSONObject();
+		identityJson.put("UIN", "{{UIN}}");
+		JSONArray handleTag = new JSONArray().put("handle");
+		List<String> selectedHandles = new ArrayList<>();
+		boolean hasBiometrics = false;
+
+		for (String fieldName : props.keySet()) {
+			if (fieldName.equals("UIN") || fieldName.equals("selectedHandles")) {
+				continue;
+			}
+			JSONObject fieldDef = props.getJSONObject(fieldName);
+			String ref = fieldDef.optString("$ref", "");
+			String fieldType = fieldDef.optString("type", "string");
+			boolean isHandle = fieldDef.optBoolean("handle", false);
+
+			if (fieldName.equals("IDSchemaVersion")) {
+				identityJson.put(fieldName, schemaVersion);
+
+			} else if (fieldName.equals("preferredLang")) {
+				identityJson.put(fieldName, "$1STLANG$");
+
+			} else if (fieldName.equals("packetCreatedOn")) {
+				// System-populated audit timestamp with no $ref/validators; emit the $TIMESTAMP$ token so
+				// inputJsonKeyWordHandeler fills a fresh UTC time per request and this template stays
+				// deterministic (hence cacheable) rather than rendering "".
+				identityJson.put(fieldName, "$TIMESTAMP$");
+
+			} else if (!ref.isEmpty() && ref.contains("simpleType")) {
+				if (isHandle) {
+					selectedHandles.add(fieldName);
+				}
+				JSONArray arr = new JSONArray();
+				for (String lang : BaseTestCase.getLanguageList()) {
+					if (lang != null && !lang.isEmpty()) {
+						JSONObject val = new JSONObject();
+						val.put("language", lang);
+						val.put("value", "TEST_" + fieldName + lang);
+						arr.put(val);
+					}
+				}
+				identityJson.put(fieldName, arr);
+
+			} else if (!ref.isEmpty() && ref.contains("documentType")) {
+				if (!isUpdate) { // update does not re-upload documents
+					JSONObject doc = new JSONObject();
+					doc.put("format", "txt");
+					doc.put("type", "DOC001");
+					doc.put("value", "fileReferenceID");
+					identityJson.put(fieldName, doc);
+				}
+
+			} else if (!ref.isEmpty() && ref.contains("biometricsType")) {
+				if (!isUpdate) { // update does not re-upload biometrics
+					JSONObject bio = new JSONObject();
+					bio.put("format", "cbeff");
+					bio.put("version", 1.0);
+					bio.put("value", "fileReferenceID");
+					identityJson.put(fieldName, bio);
+					hasBiometrics = true;
+				}
+
+			} else if (!ref.isEmpty() && ref.contains("hashType")) {
+				if (StringUtils.isBlank(AdminTestUtil.addIdentityPassword)
+						|| StringUtils.isBlank(AdminTestUtil.addIdentitySalt)) {
+					AdminTestUtil.getPasswordSaltFromKeyManager(AdminTestUtil.PASSWORD_FOR_ADDIDENTITY_AND_REGISTRATION);
+				}
+				JSONObject hash = new JSONObject();
+				hash.put("hash", AdminTestUtil.addIdentityPassword);
+				hash.put("salt", AdminTestUtil.addIdentitySalt);
+				identityJson.put(fieldName, hash);
+
+			} else if (fieldName.equals(phoneFieldName) || fieldName.equals(emailFieldName)) {
+				// Phone/email take their value from the YAML input ($PHONENUMBERFORIDENTITY$ / $EMAILVALUE$).
+				// Handled together and shape-driven so the two can't drift apart: whether either is a handle,
+				// and whether it is string or array, is per-schema. The phone placeholder is always {{phone}}.
+				String placeholder = fieldName.equals(phoneFieldName) ? "{{phone}}" : "{{" + fieldName + "}}";
+				if ("array".equals(fieldType)) {
+					JSONObject entry = new JSONObject();
+					entry.put("value", placeholder);
+					if (isHandle) {
+						entry.put("tags", handleTag);
+					}
+					identityJson.put(fieldName, new JSONArray().put(entry));
+				} else {
+					identityJson.put(fieldName, placeholder);
+				}
+				if (isHandle) {
+					selectedHandles.add(fieldName);
+				}
+
+			} else if ("array".equals(fieldType) && isHandle) {
+				JSONObject entry = new JSONObject();
+				entry.put("value", "$HANDLEVALUE:" + fieldName + "$");
+				entry.put("tags", handleTag);
+				identityJson.put(fieldName, new JSONArray().put(entry));
+				selectedHandles.add(fieldName);
+
+			} else if (isHandle) {
+				identityJson.put(fieldName, "$HANDLEVALUE:" + fieldName + "$");
+				selectedHandles.add(fieldName);
+
+			} else if (isUpdate) {
+				// Update flow: bare {{fieldName}} (renders empty if the YAML omits it).
+				identityJson.put(fieldName, "{{" + fieldName + "}}");
+
+			} else {
+				// Create flow: sentinel -> presence-aware {{schemaFieldValue "field"}} helper (see AdminTestUtil).
+				identityJson.put(fieldName,
+						AdminTestUtil.SCHEMA_FIELD_SENTINEL_PREFIX + fieldName + AdminTestUtil.SCHEMA_FIELD_SENTINEL_SUFFIX);
+			}
+		}
+
+		if (!selectedHandles.isEmpty()) {
+			identityJson.put("selectedHandles", selectedHandles);
+			AdminTestUtil.setfoundHandlesInIdSchema(true);
+		}
+
+		requestJson.getJSONObject("request").put("identity", identityJson);
+
+		if (hasBiometrics) {
+			JSONArray requestDocArray = new JSONArray();
+			JSONObject docJson = new JSONObject();
+			docJson.put("value", "{{value}}");
+			docJson.put("category", "{{category}}");
+			requestDocArray.put(docJson);
+			requestJson.getJSONObject("request").put("documents", requestDocArray);
+		}
+
+		requestJson.put("requesttime", "{{requesttime}}");
+		requestJson.put("version", "{{version}}");
+
+		logger.info((isUpdate ? "Full-schema UpdateIdentity" : "Full-schema AddIdentity") + " template: " + requestJson);
+		return requestJson.toString();
+	}
+}

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SchemaBasedIdentityTemplateBuilder.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/SchemaBasedIdentityTemplateBuilder.java
@@ -65,8 +65,8 @@ public class SchemaBasedIdentityTemplateBuilder {
 
 	private static String wrapV2(String hbs) {
 		JSONObject requestJson = new JSONObject(hbs);
-		requestJson.getJSONObject("request").put("verifiedAttributes", "$$VERIFIED_ATTRIBUTES$$");
-		return requestJson.toString().replace("\"$$VERIFIED_ATTRIBUTES$$\"", "{{{json verifiedAttributes}}}");
+		requestJson.getJSONObject("request").put("verifiedAttributes", "$VERIFIED_ATTRIBUTES$");
+		return requestJson.toString().replace("\"$VERIFIED_ATTRIBUTES$\"", "{{{json verifiedAttributes}}}");
 	}
 
 	private static String buildTemplate(boolean isUpdate) {

--- a/authentication-demo-service/pom.xml
+++ b/authentication-demo-service/pom.xml
@@ -78,7 +78,7 @@
 		<maven.jacoco.version>0.8.2</maven.jacoco.version>
 		<central.publishing.maven.plugin.version>0.7.0</central.publishing.maven.plugin.version>
 		
-		<kernel-websubclient-api.version>1.2.1-SNAPSHOT</kernel-websubclient-api.version>
+		<kernel-websubclient-api.version>1.3.0</kernel-websubclient-api.version>
 		
 	</properties>
 
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>io.mosip.authentication</groupId>
 			<artifactId>authentication-core</artifactId>
-			<version>1.2.1-SNAPSHOT</version>
+			<version>1.3.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -134,7 +134,7 @@
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-core</artifactId>
-			<version>1.2.1-SNAPSHOT</version>
+			<version>1.3.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework.boot</groupId>
@@ -215,7 +215,7 @@
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-templatemanager-velocity</artifactId>
-			<version>1.2.1-SNAPSHOT</version>
+			<version>1.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -238,7 +238,7 @@
 		<dependency>
 			<groupId>io.mosip.kernel</groupId>
 			<artifactId>kernel-keymanager-service</artifactId>
-			<version>1.2.1-SNAPSHOT</version>
+			<version>1.3.0</version>
 			<classifier>lib</classifier>
 			<exclusions>
 				<exclusion>
@@ -269,7 +269,7 @@
 			<dependency>
 				<groupId>io.mosip.kernel</groupId>
 				<artifactId>kernel-bom</artifactId>
-				<version>1.2.1-SNAPSHOT</version>
+				<version>1.3.0</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
MOSIP-45308 - Created helper class for the Dynamic request body generation with full ID Schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added schema-driven generation of Add Identity and Update Identity request templates, including V2 variants with verified-attributes rendering.
  - Introduced support for schema-defined handle fields, including handle-value token handling.
  - Added `requiredHandleFields` to test case definitions to enable skipping when required handle declarations are missing.
- **Bug Fixes**
  - Prevented missing identity scalar fields from defaulting to empty strings.
  - Improved template finalization and regeneration so handle and verified-attribute values are reliably produced.
  - Enhanced identity field value generation to better match live schema validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->