### PR TITLE
MOSIP-45312 - Add content-type override and STOMP ERROR frame support to WebSocketClientU

### DIFF
--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/WebSocketClientUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/WebSocketClientUtil.java
@@ -119,9 +119,14 @@ public class WebSocketClientUtil extends Endpoint {
 
 
     public void sendMessage(String messageContent) {
+        sendMessage(messageContent, "application/json");
+    }
+
+    // Same as sendMessage(String) but with a caller-supplied STOMP content-type header.
+    public void sendMessage(String messageContent, String contentType) {
         if (session != null && session.isOpen()) {
             try {
-                String sendFrame = String.format("SEND\ndestination:%s\ncontent-type:application/json\n\n%s\u0000", sendDestination, messageContent);
+                String sendFrame = String.format("SEND\ndestination:%s\ncontent-type:%s\n\n%s\u0000", sendDestination, contentType, messageContent);
                 session.getBasicRemote().sendText(sendFrame);
                 logger.info("Sent message: " + sendFrame);
             } catch (Exception e) {
@@ -144,9 +149,14 @@ public class WebSocketClientUtil extends Endpoint {
         }
     }
 
-    // Method to extract the message ID from the received message (this is a placeholder)
+    // STOMP ERROR frames have no message-id header, so this counter gives each one a distinct store key.
+    private static final java.util.concurrent.atomic.AtomicLong errorFrameCounter = new java.util.concurrent.atomic.AtomicLong();
+
     private String extractMessageId(String message) {
         try {
+            if (message.startsWith("ERROR")) {
+                return "ERROR-" + errorFrameCounter.incrementAndGet();
+            }
             if (message.contains("message-id")) {
                 String[] parts = message.split("message-id:");
                 if (parts.length > 1) {

--- a/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/WebSocketClientUtil.java
+++ b/apitest-commons/src/main/java/io/mosip/testrig/apirig/utils/WebSocketClientUtil.java
@@ -85,10 +85,28 @@ public class WebSocketClientUtil extends Endpoint {
         // Assuming the message contains a message-id field
         String messageId = extractMessageId(message);
         if (messageId != null) {
-            messageStore.put(messageId, message);
+            if (messageId.startsWith("ERROR-")) {
+                retainErrorFrame(messageId, message);
+            } else {
+                messageStore.put(messageId, message);
+            }
             logger.info("Stored message with ID: " + messageId);
         } else {
             logger.warn("Received message without a valid message ID: " + message);
+        }
+    }
+
+    private static final int MAX_ERROR_FRAMES = 100;
+    private static final java.util.concurrent.ConcurrentLinkedDeque<String> errorFrameKeys = new java.util.concurrent.ConcurrentLinkedDeque<>();
+
+    private static void retainErrorFrame(String key, String message) {
+        messageStore.put(key, message);
+        errorFrameKeys.addLast(key);
+        while (errorFrameKeys.size() > MAX_ERROR_FRAMES) {
+            String evicted = errorFrameKeys.pollFirst();
+            if (evicted != null) {
+                messageStore.remove(evicted);
+            }
         }
     }
 
@@ -125,8 +143,9 @@ public class WebSocketClientUtil extends Endpoint {
     // Same as sendMessage(String) but with a caller-supplied STOMP content-type header.
     public void sendMessage(String messageContent, String contentType) {
         if (session != null && session.isOpen()) {
+            String encodedContentType = stompEncodeHeaderValue(contentType);
             try {
-                String sendFrame = String.format("SEND\ndestination:%s\ncontent-type:%s\n\n%s\u0000", sendDestination, contentType, messageContent);
+                String sendFrame = String.format("SEND\ndestination:%s\ncontent-type:%s\n\n%s\u0000", sendDestination, encodedContentType, messageContent);
                 session.getBasicRemote().sendText(sendFrame);
                 logger.info("Sent message: " + sendFrame);
             } catch (Exception e) {
@@ -136,6 +155,13 @@ public class WebSocketClientUtil extends Endpoint {
             logger.warn("Connection is not open. Unable to send message.");
             session = null;
         }
+    }
+
+    private static String stompEncodeHeaderValue(String value) {
+        if (value.indexOf('\u0000') >= 0) {
+            throw new IllegalArgumentException("STOMP header value must not contain a NUL character");
+        }
+        return value.replace("\\", "\\\\").replace(":", "\\c").replace("\n", "\\n").replace("\r", "\\r");
     }
 
     public void closeConnection() {


### PR DESCRIPTION
MOSIP-45312 - Add content-type override and STOMP ERROR frame support to WebSocketClientU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending WebSocket messages with a caller-specified content type.
  * Preserved JSON as the default content type for existing message-sending behavior.
  * Improved handling of STOMP error responses by assigning unique identifiers.

* **Bug Fixes**
  * Improved header safety by escaping values and rejecting invalid null characters.
  * Limited retained STOMP error responses to the 100 most recent entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->